### PR TITLE
ci: Add environment to e2e pipeline and bump to 1.5.0

### DIFF
--- a/.github/workflows/e2e-preset-test.yml
+++ b/.github/workflows/e2e-preset-test.yml
@@ -21,7 +21,8 @@ jobs:
   setup:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: self-hosted
-    outputs: 
+    environment: e2e-test
+    outputs:
         IMG_TAG: ${{ steps.set_final_tag.outputs.IMG_TAG }}
     steps: 
       - name: Determine tag from dispatch
@@ -83,6 +84,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     needs: setup
     runs-on: self-hosted
+    environment: e2e-test
     strategy:
       fail-fast: false
       matrix:
@@ -166,14 +168,11 @@ jobs:
             fi
 
       - name: 'Az CLI login'
-        uses: azure/login@v1.4.6
+        uses: azure/login@v1.5.0
         with:
-            client-id: ${{ secrets.AZURE_KDM_PRESET_SELF_RUNNER_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            allow-no-subscriptions: true
-      
-      - name: 'Set subscription'
-        run: az account set --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+          client-id: ${{ secrets.AZURE_KDM_PRESET_SELF_RUNNER_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
       - name: 'Check if Image exists in ACR'
         id: check_image

--- a/.github/workflows/kaito-e2e.yaml
+++ b/.github/workflows/kaito-e2e.yaml
@@ -7,22 +7,23 @@ concurrency:
 on:
   push:
     branches: [main]
-    paths-ignore: ['docs/**', '**.md', '**.mdx', '**.png', '**.jpg']
+    paths-ignore: [ 'docs/**', '**.md', '**.mdx', '**.png', '**.jpg' ]
   pull_request:
     branches: [main]
-    paths-ignore: ['docs/**', '**.md', '**.mdx', '**.png', '**.jpg']
+    paths-ignore: [ 'docs/**', '**.md', '**.mdx', '**.png', '**.jpg' ]
 
 env:
-  GO_VERSION: "1.20"
+  GO_VERSION: '1.20'
+  E2E_IMG_TAG: 'kaito-e2e'
 
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read # This is required for actions/checkout
+
 jobs:
-  e2e-tests:
-    env:
-      E2E_IMG_TAG: "kaito-e2e"
+  e2e-test:
     runs-on: ubuntu-latest
+    environment: e2e-test
     steps:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
@@ -54,21 +55,18 @@ jobs:
 
       - name: Install Azure CLI latest
         run: |
-            if ! which az > /dev/null; then
-                echo "Azure CLI not found. Installing..."
-                curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-            else
-                echo "Azure CLI already installed."
-            fi
+          if ! which az > /dev/null; then
+              echo "Azure CLI not found. Installing..."
+              curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          else
+              echo "Azure CLI already installed."
+          fi
 
-      - uses: azure/login@v1.4.6
+      - uses: azure/login@v1.5.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-    
-      - name: 'Set subscription'
-        run: az account set --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       
       - uses: azure/setup-helm@v3
         with:
@@ -115,7 +113,7 @@ jobs:
           AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
           AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
 
-      - uses: azure/login@v1.4.6
+      - uses: azure/login@v1.5.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/preset-image-build.yml
+++ b/.github/workflows/preset-image-build.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   setup:
     runs-on: [self-hosted, 'username:runner-0']
+    environment: e2e-test
     outputs:
       image_tag: ${{ steps.set_tag.outputs.image_tag }}
       FALCON_MODIFIED: ${{ steps.check_modified_paths.outputs.FALCON_MODIFIED }}
@@ -138,6 +139,7 @@ jobs:
   matrix_prep:
     needs: setup
     runs-on: self-hosted
+    environment: e2e-test
     outputs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
       matrix_empty: ${{ steps.set_matrix.outputs.matrix_empty }}
@@ -165,6 +167,7 @@ jobs:
   build-models: 
     needs: [setup, matrix_prep]
     runs-on: self-hosted
+    environment: e2e-test
     if: ${{needs.matrix_prep.outputs.matrix_empty == 'false'}}
     strategy:
       fail-fast: false
@@ -177,14 +180,11 @@ jobs:
           fetch-depth: 0
 
       - name: 'Az CLI login'
-        uses: azure/login@v1.4.6
+        uses: azure/login@v1.5.0
         with:
           client-id: ${{ secrets.AZURE_KDM_PRESET_SELF_RUNNER_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-  
-      - name: 'Set subscription'
-        run: az account set --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+          subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
 
       - name: 'Attach and Login to ACR'
         id: acr_login

--- a/.github/workflows/publish-image-acr.yml
+++ b/.github/workflows/publish-image-acr.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION  }}
+
       - name: Set Image Tag
         run: |
           echo "IMG_TAG=$(echo "${{ github.ref }}" | tr -d refs/tags/v)" >> $GITHUB_ENV
@@ -29,12 +30,14 @@ jobs:
           fetch-depth: 0
           submodules: true
           ref: ${{ env.REPO_TAG }}
+
       - name: 'Az CLI login'
-        uses: azure/login@v1.4.7
+        uses: azure/login@v1.5.0
         with:
           client-id: ${{ secrets.KAITO_MCR_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.KAITO_MCR_SUBSCRIPTION_ID }}
+
       - name: 'Publish to ACR'
         id: Publish
         run: |


### PR DESCRIPTION
- As stated in https://github.com/Azure/login/issues/375, a wild card branch option is not supported for Azure federated identity. Therefore, we are adding an environment to the e2e pipeline to fix dependabot PRs issue.
- Bump azure/login Github action to v1.5.0