### PR TITLE
chore: Refactor to implement model plugin - part 1

### DIFF
--- a/cmd/models.go
+++ b/cmd/models.go
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package main
+
+import (
+	_ "github.com/azure/kaito/presets/llama2chat"
+)

--- a/pkg/inference/interface.go
+++ b/pkg/inference/interface.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package inference
+
+type Model interface {
+	GetInferenceParameters() *PresetInferenceParam
+	NeedStatefulSet() bool
+	NeedHeadlessService() bool
+}

--- a/pkg/inference/preset-inference-types.go
+++ b/pkg/inference/preset-inference-types.go
@@ -83,6 +83,35 @@ var (
 	defaultImagePullSecrets = []corev1.LocalObjectReference{}
 )
 
+// TODO: remove the above local variables starting with lower cases.
+var (
+	DefaultTorchRunParams = map[string]string{
+		"nnodes":         DefaultNnodes,
+		"nproc_per_node": DefaultNprocPerNode,
+		"node_rank":      DefaultNodeRank,
+		"master_addr":    DefaultMasterAddr,
+		"master_port":    DefaultMasterPort,
+	}
+
+	DefaultTorchRunRdzvParams = map[string]string{
+		"max_restarts":  DefaultMaxRestarts,
+		"rdzv_id":       DefaultRdzvId,
+		"rdzv_backend":  DefaultRdzvBackend,
+		"rdzv_endpoint": DefaultRdzvEndpoint,
+	}
+
+	DefaultAccelerateParams = map[string]string{
+		"config_file":   DefaultConfigFile,
+		"num_processes": DefaultNumProcesses,
+		"num_machines":  DefaultNumMachines,
+		"machine_rank":  DefaultMachineRank,
+		"gpu_ids":       DefaultGPUIds,
+	}
+
+	DefaultAccessMode       = "public"
+	DefaultImagePullSecrets = []corev1.LocalObjectReference{}
+)
+
 // PresetInferenceParam defines the preset inference.
 type PresetInferenceParam struct {
 	ModelName              string

--- a/pkg/utils/plugin/plugin.go
+++ b/pkg/utils/plugin/plugin.go
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package plugin
+
+import (
+	"sync"
+
+	"github.com/azure/kaito/pkg/inference"
+)
+
+type Registration struct {
+	Name     string
+	Instance inference.Model
+}
+
+type ModelRegister struct {
+	sync.RWMutex
+	models map[string]*Registration
+}
+
+var KaitoModelRegister ModelRegister
+
+// Register allows model to be added
+func (reg *ModelRegister) Register(r *Registration) {
+	reg.Lock()
+	defer reg.Unlock()
+	if r.Name == "" {
+		panic("model name is not specified")
+	}
+
+	if reg.models == nil {
+		reg.models = make(map[string]*Registration)
+	}
+
+	reg.models[r.Name] = r
+}
+
+func (reg *ModelRegister) MustGet(name string) inference.Model {
+	reg.Lock()
+	defer reg.Unlock()
+	if _, ok := reg.models[name]; ok {
+		return reg.models[name].Instance
+	}
+	panic("model is not registered")
+}

--- a/presets/llama2chat/model.go
+++ b/presets/llama2chat/model.go
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package llama2chat
+
+import (
+	"time"
+
+	"github.com/azure/kaito/pkg/inference"
+	"github.com/azure/kaito/pkg/utils/plugin"
+)
+
+func init() {
+	plugin.KaitoModelRegister.Register(&plugin.Registration{
+		Name:     "llama-2-7b-chat",
+		Instance: &llama2chatA,
+	})
+	plugin.KaitoModelRegister.Register(&plugin.Registration{
+		Name:     "llama-2-13b-chat",
+		Instance: &llama2chatB,
+	})
+	plugin.KaitoModelRegister.Register(&plugin.Registration{
+		Name:     "llama-2-70b-chat",
+		Instance: &llama2chatC,
+	})
+}
+
+var (
+	baseCommandPresetLlama = "cd /workspace/llama/llama-2 && torchrun"
+	llamaRunParams         = map[string]string{
+		"max_seq_len":    "512",
+		"max_batch_size": "8",
+	}
+	llamaChatInferenceFile = "inference-api.py"
+)
+
+var llama2chatA llama2Chat7b
+
+type llama2Chat7b struct{}
+
+func (*llama2Chat7b) GetInferenceParameters() *inference.PresetInferenceParam {
+	return &inference.PresetInferenceParam{
+		ModelName:              "LLaMa2",
+		Image:                  "",
+		ImagePullSecrets:       inference.DefaultImagePullSecrets,
+		AccessMode:             inference.DefaultAccessMode,
+		DiskStorageRequirement: "34Gi",
+		GPURequirement:         "1",
+		GPUMemoryRequirement:   "16Gi",
+		TorchRunParams:         inference.DefaultTorchRunParams,
+		TorchRunRdzvParams:     inference.DefaultTorchRunRdzvParams,
+		ModelRunParams:         llamaRunParams,
+		InferenceFile:          llamaChatInferenceFile,
+		DeploymentTimeout:      time.Duration(10) * time.Minute,
+		BaseCommand:            baseCommandPresetLlama,
+		WorldSize:              1,
+		DefaultVolumeMountPath: "/dev/shm",
+	}
+
+}
+func (*llama2Chat7b) NeedStatefulSet() bool {
+	return true
+}
+func (*llama2Chat7b) NeedHeadlessService() bool {
+	return false
+}
+
+var llama2chatB llama2Chat13b
+
+type llama2Chat13b struct{}
+
+func (*llama2Chat13b) GetInferenceParameters() *inference.PresetInferenceParam {
+	return &inference.PresetInferenceParam{
+		ModelName:              "LLaMa2",
+		Image:                  "",
+		ImagePullSecrets:       inference.DefaultImagePullSecrets,
+		AccessMode:             inference.DefaultAccessMode,
+		DiskStorageRequirement: "46Gi",
+		GPURequirement:         "2",
+		GPUMemoryRequirement:   "16Gi",
+		TorchRunParams:         inference.DefaultTorchRunParams,
+		TorchRunRdzvParams:     inference.DefaultTorchRunRdzvParams,
+		ModelRunParams:         llamaRunParams,
+		InferenceFile:          llamaChatInferenceFile,
+		DeploymentTimeout:      time.Duration(20) * time.Minute,
+		BaseCommand:            baseCommandPresetLlama,
+		WorldSize:              2,
+		DefaultVolumeMountPath: "/dev/shm",
+	}
+}
+func (*llama2Chat13b) NeedStatefulSet() bool {
+	return true
+}
+func (*llama2Chat13b) NeedHeadlessService() bool {
+	return true
+}
+
+var llama2chatC llama2Chat70b
+
+type llama2Chat70b struct{}
+
+func (*llama2Chat70b) GetInferenceParameters() *inference.PresetInferenceParam {
+	return &inference.PresetInferenceParam{
+		ModelName:              "LLaMa2",
+		Image:                  "",
+		ImagePullSecrets:       inference.DefaultImagePullSecrets,
+		AccessMode:             inference.DefaultAccessMode,
+		DiskStorageRequirement: "158Gi",
+		GPURequirement:         "8",
+		GPUMemoryRequirement:   "19Gi",
+		TorchRunParams:         inference.DefaultTorchRunParams,
+		TorchRunRdzvParams:     inference.DefaultTorchRunRdzvParams,
+		ModelRunParams:         llamaRunParams,
+		InferenceFile:          llamaChatInferenceFile,
+		DeploymentTimeout:      time.Duration(30) * time.Minute,
+		BaseCommand:            baseCommandPresetLlama,
+		WorldSize:              8,
+		DefaultVolumeMountPath: "/dev/shm",
+	}
+}
+func (*llama2Chat70b) NeedStatefulSet() bool {
+	return true
+}
+func (*llama2Chat70b) NeedHeadlessService() bool {
+	return true
+}


### PR DESCRIPTION
This is the first PR of a series of refactoring changes for moving all model specific configurations into preset directory so that the core controllers will be model agnostic. 

- This change introduces Kaito model plugin.
- This change adds the common model interface.
- This change adds corresponding inference implementation for llama-2-chat model family. 

NOTE: the added code is not activated (used) in the controller yet. 