### PR TITLE
chore: Refactor to implement model plugin - part 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-REGISTRY ?= mcr.microsoft.com/aks/kaito
+REGISTRY ?= YOUR_REGISTRY
 IMG_NAME ?= workspace
 VERSION ?= v0.1.0
 IMG_TAG ?= $(subst v,,$(VERSION))
@@ -132,7 +132,7 @@ az-patch-install-helm: ## Update Azure client env vars and settings in helm valu
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
-	go build -o bin/manager cmd/main.go
+	go build -o bin/manager cmd/*.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/docker/kaito/Dockerfile
+++ b/docker/kaito/Dockerfile
@@ -16,9 +16,10 @@ RUN \
     go mod download
 
 # Copy the go source
-COPY cmd/main.go cmd/main.go
+COPY cmd/ cmd/
 COPY api/ api/
 COPY pkg/ pkg/
+COPY presets/ presets/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
@@ -27,7 +28,7 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,id=kaito-controller,sharing=locked,target=/go/pkg/mod \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager cmd/main.go
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager cmd/*.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -393,18 +393,20 @@ func (c *WorkspaceReconciler) ensureService(ctx context.Context, wObj *kaitov1al
 		return nil
 	}
 
-	presetName := string(wObj.Inference.Preset.Name)
-	model := plugin.KaitoModelRegister.MustGet(presetName)
-	serviceObj := resources.GenerateServiceManifest(ctx, wObj, serviceType, model.SupportDistributedInference())
-	err = resources.CreateResource(ctx, serviceObj, c.Client)
-	if err != nil {
-		return err
-	}
-	if model.SupportDistributedInference() {
-		headlessService := resources.GenerateHeadlessServiceManifest(ctx, wObj)
-		err = resources.CreateResource(ctx, headlessService, c.Client)
+	if wObj.Inference.Preset != nil {
+		presetName := string(wObj.Inference.Preset.Name)
+		model := plugin.KaitoModelRegister.MustGet(presetName)
+		serviceObj := resources.GenerateServiceManifest(ctx, wObj, serviceType, model.SupportDistributedInference())
+		err = resources.CreateResource(ctx, serviceObj, c.Client)
 		if err != nil {
 			return err
+		}
+		if model.SupportDistributedInference() {
+			headlessService := resources.GenerateHeadlessServiceManifest(ctx, wObj)
+			err = resources.CreateResource(ctx, headlessService, c.Client)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/azure/kaito/pkg/machine"
 	"github.com/azure/kaito/pkg/resources"
 	"github.com/azure/kaito/pkg/utils"
+	"github.com/azure/kaito/pkg/utils/plugin"
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
@@ -92,12 +93,8 @@ func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *ka
 		}
 		return reconcile.Result{}, err
 	}
-	useHeadlessService := false
-	if wObj.Inference.Preset != nil && strings.Contains(string(wObj.Inference.Preset.Name), "llama") {
-		useHeadlessService = true
-	}
 
-	if err := c.ensureService(ctx, wObj, useHeadlessService); err != nil {
+	if err := c.ensureService(ctx, wObj); err != nil {
 		if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeReady, metav1.ConditionFalse,
 			"workspaceFailed", err.Error()); updateErr != nil {
 			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
@@ -106,7 +103,7 @@ func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *ka
 		return reconcile.Result{}, err
 	}
 
-	if err = c.applyInference(ctx, wObj, useHeadlessService); err != nil {
+	if err = c.applyInference(ctx, wObj); err != nil {
 		if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeReady, metav1.ConditionFalse,
 			"workspaceFailed", err.Error()); updateErr != nil {
 			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
@@ -301,15 +298,8 @@ func (c *WorkspaceReconciler) validateNodeInstanceType(ctx context.Context, wObj
 func (c *WorkspaceReconciler) createAndValidateNode(ctx context.Context, wObj *kaitov1alpha1.Workspace) (*corev1.Node, error) {
 	var machineOSDiskSize string
 	if wObj.Inference.Preset != nil && wObj.Inference.Preset.Name != "" {
-		presetName := wObj.Inference.Preset.Name
-		if _, exists := inference.Llama2PresetInferences[presetName]; exists {
-			machineOSDiskSize = inference.Llama2PresetInferences[presetName].DiskStorageRequirement
-		} else if _, exists := inference.FalconPresetInferences[presetName]; exists {
-			machineOSDiskSize = inference.FalconPresetInferences[presetName].DiskStorageRequirement
-		} else {
-			err := fmt.Errorf("preset model %s is not supported", presetName)
-			return nil, err
-		}
+		presetName := string(wObj.Inference.Preset.Name)
+		machineOSDiskSize = plugin.KaitoModelRegister.MustGet(presetName).GetInferenceParameters().DiskStorageRequirement
 	}
 	if machineOSDiskSize == "" {
 		machineOSDiskSize = "0" // The default OS size is used
@@ -382,7 +372,7 @@ func (c *WorkspaceReconciler) ensureNodePlugins(ctx context.Context, wObj *kaito
 	}
 }
 
-func (c *WorkspaceReconciler) ensureService(ctx context.Context, wObj *kaitov1alpha1.Workspace, useHeadlessService bool) error {
+func (c *WorkspaceReconciler) ensureService(ctx context.Context, wObj *kaitov1alpha1.Workspace) error {
 	serviceType := corev1.ServiceTypeClusterIP
 	wAnnotation := wObj.GetAnnotations()
 
@@ -402,16 +392,15 @@ func (c *WorkspaceReconciler) ensureService(ctx context.Context, wObj *kaitov1al
 	} else {
 		return nil
 	}
-	var isStatefulSet bool
-	if wObj.Inference.Preset != nil {
-		isStatefulSet = strings.Contains(string(wObj.Inference.Preset.Name), "llama")
-	}
-	serviceObj := resources.GenerateServiceManifest(ctx, wObj, serviceType, isStatefulSet)
+
+	presetName := string(wObj.Inference.Preset.Name)
+	model := plugin.KaitoModelRegister.MustGet(presetName)
+	serviceObj := resources.GenerateServiceManifest(ctx, wObj, serviceType, model.SupportDistributedInference())
 	err = resources.CreateResource(ctx, serviceObj, c.Client)
 	if err != nil {
 		return err
 	}
-	if useHeadlessService {
+	if model.SupportDistributedInference() {
 		headlessService := resources.GenerateHeadlessServiceManifest(ctx, wObj)
 		err = resources.CreateResource(ctx, headlessService, c.Client)
 		if err != nil {
@@ -421,50 +410,21 @@ func (c *WorkspaceReconciler) ensureService(ctx context.Context, wObj *kaitov1al
 	return nil
 }
 
-func (c *WorkspaceReconciler) getInferenceObjFromPreset(ctx context.Context, wObj *kaitov1alpha1.Workspace) (inference.PresetInferenceParam, error) {
-	presetName := wObj.Inference.Preset.Name
-	var inferenceObj inference.PresetInferenceParam
-	switch presetName {
-	case kaitov1alpha1.PresetLlama2AModel:
-		inferenceObj = inference.Llama2PresetInferences[kaitov1alpha1.PresetLlama2AModel]
-	case kaitov1alpha1.PresetLlama2BModel:
-		inferenceObj = inference.Llama2PresetInferences[kaitov1alpha1.PresetLlama2BModel]
-	case kaitov1alpha1.PresetLlama2CModel:
-		inferenceObj = inference.Llama2PresetInferences[kaitov1alpha1.PresetLlama2CModel]
-	case kaitov1alpha1.PresetLlama2AChat:
-		inferenceObj = inference.Llama2PresetInferences[kaitov1alpha1.PresetLlama2AChat]
-	case kaitov1alpha1.PresetLlama2BChat:
-		inferenceObj = inference.Llama2PresetInferences[kaitov1alpha1.PresetLlama2BChat]
-	case kaitov1alpha1.PresetLlama2CChat:
-		inferenceObj = inference.Llama2PresetInferences[kaitov1alpha1.PresetLlama2CChat]
-	case kaitov1alpha1.PresetFalcon7BModel:
-		inferenceObj = inference.FalconPresetInferences[kaitov1alpha1.PresetFalcon7BModel]
-	case kaitov1alpha1.PresetFalcon7BInstructModel:
-		inferenceObj = inference.FalconPresetInferences[kaitov1alpha1.PresetFalcon7BInstructModel]
-	case kaitov1alpha1.PresetFalcon40BModel:
-		inferenceObj = inference.FalconPresetInferences[kaitov1alpha1.PresetFalcon40BModel]
-	case kaitov1alpha1.PresetFalcon40BInstructModel:
-		inferenceObj = inference.FalconPresetInferences[kaitov1alpha1.PresetFalcon40BInstructModel]
-	default:
-		err := fmt.Errorf("preset model %s is not supported", presetName)
-		return inference.PresetInferenceParam{}, err
-	}
-
-	inferenceObj.AccessMode = string(wObj.Inference.Preset.PresetMeta.AccessMode)
-	if inferenceObj.AccessMode == "private" && wObj.Inference.Preset.PresetOptions.Image != "" {
-		inferenceObj.Image = wObj.Inference.Preset.PresetOptions.Image
+func (c *WorkspaceReconciler) updateInferenceParamFromWorkspace(ctx context.Context, wObj *kaitov1alpha1.Workspace, inferenceParam *inference.PresetInferenceParam) {
+	inferenceParam.AccessMode = string(wObj.Inference.Preset.PresetMeta.AccessMode)
+	if inferenceParam.AccessMode == "private" && wObj.Inference.Preset.PresetOptions.Image != "" {
+		inferenceParam.Image = wObj.Inference.Preset.PresetOptions.Image
 
 		imagePullSecretRefs := []corev1.LocalObjectReference{}
 		for _, secretName := range wObj.Inference.Preset.PresetOptions.ImagePullSecrets {
 			imagePullSecretRefs = append(imagePullSecretRefs, corev1.LocalObjectReference{Name: secretName})
 		}
-		inferenceObj.ImagePullSecrets = imagePullSecretRefs
+		inferenceParam.ImagePullSecrets = imagePullSecretRefs
 	}
-	return inferenceObj, nil
 }
 
 // applyInference applies inference spec.
-func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1alpha1.Workspace, useHeadlessService bool) error {
+func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1alpha1.Workspace) error {
 	var err error
 	func() {
 		if wObj.Inference.Template != nil {
@@ -478,16 +438,16 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 				return
 			}
 		} else if wObj.Inference.Preset != nil {
+			presetName := string(wObj.Inference.Preset.Name)
+			model := plugin.KaitoModelRegister.MustGet(presetName)
+
+			inferenceParam := model.GetInferenceParameters()
+
+			c.updateInferenceParamFromWorkspace(ctx, wObj, inferenceParam)
 			// TODO: we only do create if it does not exist for preset model. Need to document it.
-			var inferenceObj inference.PresetInferenceParam
-			inferenceObj, err = c.getInferenceObjFromPreset(ctx, wObj)
-			if err != nil {
-				klog.ErrorS(err, "unable to retrieve inference object from preset", "workspace", klog.KObj(wObj))
-				return
-			}
 
 			var existingObj client.Object
-			if inferenceObj.ModelName == "LLaMa2" {
+			if model.SupportDistributedInference() {
 				existingObj = &appsv1.StatefulSet{}
 			} else {
 				existingObj = &appsv1.Deployment{}
@@ -496,17 +456,17 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 
 			if err = resources.GetResource(ctx, wObj.Name, wObj.Namespace, c.Client, existingObj); err == nil {
 				klog.InfoS("An inference workload already exists for workspace", "workspace", klog.KObj(wObj))
-				if err = resources.CheckResourceStatus(existingObj, c.Client, inferenceObj.DeploymentTimeout); err != nil {
+				if err = resources.CheckResourceStatus(existingObj, c.Client, inferenceParam.DeploymentTimeout); err != nil {
 					return
 				}
 			} else if apierrors.IsNotFound(err) {
 				var workloadObj client.Object
 				// Need to create a new workload
-				workloadObj, err = inference.CreatePresetInference(ctx, wObj, inferenceObj, useHeadlessService, c.Client)
+				workloadObj, err = inference.CreatePresetInference(ctx, wObj, inferenceParam, model.SupportDistributedInference(), c.Client)
 				if err != nil {
 					return
 				}
-				if err = resources.CheckResourceStatus(workloadObj, c.Client, inferenceObj.DeploymentTimeout); err != nil {
+				if err = resources.CheckResourceStatus(workloadObj, c.Client, inferenceParam.DeploymentTimeout); err != nil {
 					return
 				}
 			}

--- a/pkg/inference/interface.go
+++ b/pkg/inference/interface.go
@@ -4,6 +4,5 @@ package inference
 
 type Model interface {
 	GetInferenceParameters() *PresetInferenceParam
-	NeedStatefulSet() bool
-	NeedHeadlessService() bool
+	SupportDistributedInference() bool //If true, the model workload will be a StatefulSet, using the torch elastic runtime framework.
 }

--- a/pkg/inference/preset-inferences_test.go
+++ b/pkg/inference/preset-inferences_test.go
@@ -132,7 +132,7 @@ func TestCreatePresetInference(t *testing.T) {
 			mockClient := utils.NewClient()
 			tc.callMocks(mockClient)
 
-			workspace := utils.MockWorkspace
+			workspace := utils.MockWorkspaceWithPreset
 			workspace.Resource.Count = &tc.nodeCount
 
 			useHeadlessSvc := false
@@ -155,7 +155,7 @@ func TestCreatePresetInference(t *testing.T) {
 			}
 			mockClient.CreateOrUpdateObjectInMap(svc)
 
-			createdObject, _ := CreatePresetInference(context.TODO(), workspace, inferenceObj, useHeadlessSvc, mockClient)
+			createdObject, _ := CreatePresetInference(context.TODO(), workspace, &inferenceObj, useHeadlessSvc, mockClient)
 			createdWorkload := ""
 			switch createdObject.(type) {
 			case *appsv1.Deployment:

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -153,7 +153,7 @@ func TestWaitForPendingMachines(t *testing.T) {
 				mockClient.CreateOrUpdateObjectInMap(mockMachine)
 			}
 
-			err := WaitForPendingMachines(context.Background(), utils.MockWorkspace, mockClient)
+			err := WaitForPendingMachines(context.Background(), utils.MockWorkspaceWithPreset, mockClient)
 			if tc.expectedError == nil {
 				assert.Check(t, err == nil, "Not expected to return error")
 			} else {
@@ -165,7 +165,7 @@ func TestWaitForPendingMachines(t *testing.T) {
 
 func TestGenerateMachineManifiest(t *testing.T) {
 	t.Run("Should generate a machine object from the given workspace", func(t *testing.T) {
-		mockWorkspace := utils.MockWorkspace
+		mockWorkspace := utils.MockWorkspaceWithPreset
 
 		machine := GenerateMachineManifest(context.Background(), "0", mockWorkspace)
 

--- a/pkg/resources/manifests_test.go
+++ b/pkg/resources/manifests_test.go
@@ -21,7 +21,7 @@ func TestGenerateStatefulSetManifest(t *testing.T) {
 	for _, useHeadlessSvc := range options {
 		t.Run(fmt.Sprintf("generate statefulset with headlessSvc %v", useHeadlessSvc), func(t *testing.T) {
 
-			workspace := utils.MockWorkspace
+			workspace := utils.MockWorkspaceWithPreset
 
 			obj := GenerateStatefulSetManifest(context.TODO(), workspace,
 				"",  //imageName
@@ -66,7 +66,7 @@ func TestGenerateStatefulSetManifest(t *testing.T) {
 func TestGenerateDeploymentManifest(t *testing.T) {
 	t.Run("generate deployment", func(t *testing.T) {
 
-		workspace := utils.MockWorkspace
+		workspace := utils.MockWorkspaceWithPreset
 
 		obj := GenerateDeploymentManifest(context.TODO(), workspace,
 			"",  //imageName
@@ -145,7 +145,7 @@ func TestGenerateServiceManifest(t *testing.T) {
 
 	for _, isStatefulSet := range options {
 		t.Run(fmt.Sprintf("generate service, isStatefulSet %v", isStatefulSet), func(t *testing.T) {
-			workspace := utils.MockWorkspace
+			workspace := utils.MockWorkspaceWithPreset
 			obj := GenerateServiceManifest(context.TODO(), workspace, v1.ServiceTypeClusterIP, isStatefulSet)
 
 			svcSelector := map[string]string{
@@ -164,7 +164,7 @@ func TestGenerateServiceManifest(t *testing.T) {
 func TestGenerateHeadlessServiceManifest(t *testing.T) {
 
 	t.Run("generate headless service", func(t *testing.T) {
-		workspace := utils.MockWorkspace
+		workspace := utils.MockWorkspaceWithPreset
 		obj := GenerateHeadlessServiceManifest(context.TODO(), workspace)
 
 		svcSelector := map[string]string{

--- a/pkg/utils/plugin/plugin.go
+++ b/pkg/utils/plugin/plugin.go
@@ -43,3 +43,13 @@ func (reg *ModelRegister) MustGet(name string) inference.Model {
 	}
 	panic("model is not registered")
 }
+
+func (reg *ModelRegister) ListModelNames() []string {
+	reg.Lock()
+	defer reg.Unlock()
+	n := []string{}
+	for k, _ := range reg.models {
+		n = append(n, k)
+	}
+	return n
+}

--- a/pkg/utils/plugin/plugin.go
+++ b/pkg/utils/plugin/plugin.go
@@ -48,7 +48,7 @@ func (reg *ModelRegister) ListModelNames() []string {
 	reg.Lock()
 	defer reg.Unlock()
 	n := []string{}
-	for k, _ := range reg.models {
+	for k := range reg.models {
 		n = append(n, k)
 	}
 	return n

--- a/pkg/utils/testUtils.go
+++ b/pkg/utils/testUtils.go
@@ -145,8 +145,6 @@ var (
 
 var (
 	gpuNodeCount = 1
-
-	gpuNodeCount2 = 2
 )
 
 var (

--- a/pkg/utils/testUtils.go
+++ b/pkg/utils/testUtils.go
@@ -21,7 +21,7 @@ const (
 )
 
 var (
-	MockWorkspace = &v1alpha1.Workspace{
+	MockWorkspaceDistributedModel = &v1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testWorkspace",
 			Namespace: "kaito",
@@ -38,7 +38,7 @@ var (
 		Inference: v1alpha1.InferenceSpec{
 			Preset: &v1alpha1.PresetSpec{
 				PresetMeta: v1alpha1.PresetMeta{
-					Name: "llama-2-7b-chat",
+					Name: "test-distributed-model",
 				},
 			},
 		},
@@ -46,32 +46,7 @@ var (
 )
 
 var (
-	MockWorkspaceWithBadPreset = &v1alpha1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testWorkspace",
-			Namespace: "kaito",
-		},
-		Resource: v1alpha1.ResourceSpec{
-			Count:        &gpuNodeCount2,
-			InstanceType: "Standard_NC12s_v3",
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"apps": "test",
-				},
-			},
-		},
-		Inference: v1alpha1.InferenceSpec{
-			Preset: &v1alpha1.PresetSpec{
-				PresetMeta: v1alpha1.PresetMeta{
-					Name: "does-not-exist",
-				},
-			},
-		},
-	}
-)
-
-var (
-	MockWorkspaceWithFalconPreset = &v1alpha1.Workspace{
+	MockWorkspaceWithPreset = &v1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testWorkspace",
 			Namespace: "kaito",
@@ -88,7 +63,7 @@ var (
 		Inference: v1alpha1.InferenceSpec{
 			Preset: &v1alpha1.PresetSpec{
 				PresetMeta: v1alpha1.PresetMeta{
-					Name: "falcon-7b",
+					Name: "test-model",
 				},
 			},
 		},

--- a/presets/models/falcon/model.go
+++ b/presets/models/falcon/model.go
@@ -71,10 +71,7 @@ func (*falcon7b) GetInferenceParameters() *inference.PresetInferenceParam {
 	}
 
 }
-func (*falcon7b) NeedStatefulSet() bool {
-	return false
-}
-func (*falcon7b) NeedHeadlessService() bool {
+func (*falcon7b) SupportDistributedInference() bool {
 	return false
 }
 
@@ -100,10 +97,7 @@ func (*falcon7bInst) GetInferenceParameters() *inference.PresetInferenceParam {
 	}
 
 }
-func (*falcon7bInst) NeedStatefulSet() bool {
-	return false
-}
-func (*falcon7bInst) NeedHeadlessService() bool {
+func (*falcon7bInst) SupportDistributedInference() bool {
 	return false
 }
 
@@ -129,10 +123,7 @@ func (*falcon40b) GetInferenceParameters() *inference.PresetInferenceParam {
 	}
 
 }
-func (*falcon40b) NeedStatefulSet() bool {
-	return false
-}
-func (*falcon40b) NeedHeadlessService() bool {
+func (*falcon40b) SupportDistributedInference() bool {
 	return false
 }
 
@@ -158,9 +149,6 @@ func (*falcon40bInst) GetInferenceParameters() *inference.PresetInferenceParam {
 	}
 
 }
-func (*falcon40bInst) NeedStatefulSet() bool {
-	return false
-}
-func (*falcon40bInst) NeedHeadlessService() bool {
+func (*falcon40bInst) SupportDistributedInference() bool {
 	return false
 }

--- a/presets/models/llama2/model.go
+++ b/presets/models/llama2/model.go
@@ -57,10 +57,7 @@ func (*llama2Text7b) GetInferenceParameters() *inference.PresetInferenceParam {
 	}
 
 }
-func (*llama2Text7b) NeedStatefulSet() bool {
-	return true
-}
-func (*llama2Text7b) NeedHeadlessService() bool {
+func (*llama2Text7b) SupportDistributedInference() bool {
 	return false
 }
 
@@ -87,10 +84,7 @@ func (*llama2Text13b) GetInferenceParameters() *inference.PresetInferenceParam {
 		DefaultVolumeMountPath: "/dev/shm",
 	}
 }
-func (*llama2Text13b) NeedStatefulSet() bool {
-	return true
-}
-func (*llama2Text13b) NeedHeadlessService() bool {
+func (*llama2Text13b) SupportDistributedInference() bool {
 	return true
 }
 
@@ -117,9 +111,6 @@ func (*llama2Text70b) GetInferenceParameters() *inference.PresetInferenceParam {
 		DefaultVolumeMountPath: "/dev/shm",
 	}
 }
-func (*llama2Text70b) NeedStatefulSet() bool {
-	return true
-}
-func (*llama2Text70b) NeedHeadlessService() bool {
+func (*llama2Text70b) SupportDistributedInference() bool {
 	return true
 }

--- a/presets/models/llama2chat/model.go
+++ b/presets/models/llama2chat/model.go
@@ -57,10 +57,7 @@ func (*llama2Chat7b) GetInferenceParameters() *inference.PresetInferenceParam {
 	}
 
 }
-func (*llama2Chat7b) NeedStatefulSet() bool {
-	return true
-}
-func (*llama2Chat7b) NeedHeadlessService() bool {
+func (*llama2Chat7b) SupportDistributedInference() bool {
 	return false
 }
 
@@ -87,10 +84,7 @@ func (*llama2Chat13b) GetInferenceParameters() *inference.PresetInferenceParam {
 		DefaultVolumeMountPath: "/dev/shm",
 	}
 }
-func (*llama2Chat13b) NeedStatefulSet() bool {
-	return true
-}
-func (*llama2Chat13b) NeedHeadlessService() bool {
+func (*llama2Chat13b) SupportDistributedInference() bool {
 	return true
 }
 
@@ -117,9 +111,6 @@ func (*llama2Chat70b) GetInferenceParameters() *inference.PresetInferenceParam {
 		DefaultVolumeMountPath: "/dev/shm",
 	}
 }
-func (*llama2Chat70b) NeedStatefulSet() bool {
-	return true
-}
-func (*llama2Chat70b) NeedHeadlessService() bool {
+func (*llama2Chat70b) SupportDistributedInference() bool {
 	return true
 }

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -350,7 +350,7 @@ var _ = Describe("Workspace Preset", func() {
 
 		validateAssociatedService(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), true)
+		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
 		validateWorkspaceReadiness(workspaceObj)
 	})


### PR DESCRIPTION
This change activates all model plugins. 

- Remove all hard coded model name in workspace_controller.go by using the plugin modelregister.
- Fix related UTs 
- Change the model interface for better abstraction
- Change to use Deployment for llama2-7b models.