### PR TITLE
feat: Add make target to run e2e local

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -26,12 +26,14 @@ var (
 
 var _ = SynchronizedBeforeSuite(func() []byte {
 	GetClusterClient(TestingCluster)
+	gpuNamespace := os.Getenv("GPU_NAMESPACE")
+	kaitoNamespace := os.Getenv("KAITO_NAMESPACE")
 
 	//check gpu-provisioner deployment is up and running
 	gpuProvisionerDeployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kaito-gpu-provisioner",
-			Namespace: "gpu-provisioner",
+			Namespace: gpuNamespace,
 		},
 	}
 
@@ -46,7 +48,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	kaitoWorkspaceDeployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kaito-workspace",
-			Namespace: "kaito-workspace",
+			Namespace: kaitoNamespace,
 		},
 	}
 


### PR DESCRIPTION
Add make target to help running e2e locally:
```shell
AZURE_LOCATION=westus2 make create-rg
AZURE_LOCATION=westus2 make create-aks-cluster-with-kaito
AZURE_SUBSCRIPTION_ID=<SUB_ID> AZURE_LOCATION=westus2 make prepare-kaito-addon-identity

az aks update --resource-group demo --name kaito-demo --attach-acr /subscriptions/<>/resourceGroups/<>/providers/Microsoft.ContainerRegistry/registries/<> 

# Create secret for private image pull
kubectl create secret docker-registry aimodelsregistrysecret \                                                      
          --docker-server=<> \
          --docker-username=<> \
          --docker-password=<>

AI_MODELS_REGISTRY=<> AI_MODELS_IMAGE_VERSION=0.0.1 RUN_LLAMA_13B=false \
AI_MODELS_REGISTRY_SECRET=<> GPU_NAMESPACE=kube-system KAITO_NAMESPACE=kube-system \
make kaito-workspace-e2e-test

````