### PR TITLE
fix: Update helm chart to use Release.Namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ az-patch-install-helm: ## Update Azure client env vars and settings in helm valu
 	yq -i '(.image.repository)                                              = "$(REGISTRY)/workspace"'                    ./charts/kaito/workspace/values.yaml
 	yq -i '(.image.tag)                                                     = "$(IMG_TAG)"'                               ./charts/kaito/workspace/values.yaml
 
-	helm install kaito-workspace ./charts/kaito/workspace
+	helm install kaito-workspace ./charts/kaito/workspace --namespace $(KAITO_NAMESPACE) --create-namespace
 
 ##@ Build
 
@@ -219,7 +219,7 @@ gpu-provisioner-helm:  ## Update Azure client env vars and settings in helm valu
 	yq -i '(.workloadIdentity.clientId)                                                = "$(IDENTITY_CLIENT_ID)"'                             ./charts/kaito/gpu-provisioner/values.yaml
 	yq -i '(.workloadIdentity.tenantId)                                                = "$(AZURE_TENANT_ID)"'                                ./charts/kaito/gpu-provisioner/values.yaml
 
-	helm install kaito-gpu-provisioner ./charts/kaito/gpu-provisioner
+	helm install kaito-gpu-provisioner ./charts/kaito/gpu-provisioner --namespace $(GPU_NAMESPACE) --create-namespace
 
 ##@ Build Dependencies
 

--- a/charts/kaito/gpu-provisioner/README.md
+++ b/charts/kaito/gpu-provisioner/README.md
@@ -9,7 +9,7 @@ A Helm chart for gpu-provisioner
 To install the chart with the release name `gpu-provisioner`:
 
 ```bash
-helm install gpu-provisioner ./charts/gpu-provisioner
+helm install gpu-provisioner ./charts/gpu-provisioner --namespace=gpu-provisioner --create-namespace
 ```
 
 ## Values

--- a/charts/kaito/gpu-provisioner/templates/clusterrole-core.yaml
+++ b/charts/kaito/gpu-provisioner/templates/clusterrole-core.yaml
@@ -15,7 +15,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: gpu-provisioner
-    namespace:  {{ .Values.namespace }}
+    namespace:  {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kaito/gpu-provisioner/templates/configmap-logging.yaml
+++ b/charts/kaito/gpu-provisioner/templates/configmap-logging.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gpu-provisioner-config-logging
-  namespace:  {{ .Values.namespace }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/kaito/gpu-provisioner/templates/configmap.yaml
+++ b/charts/kaito/gpu-provisioner/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: gpu-provisioner-global-settings
-  namespace:  {{ .Values.namespace }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/kaito/gpu-provisioner/templates/deployment.yaml
+++ b/charts/kaito/gpu-provisioner/templates/deployment.yaml
@@ -1,15 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}
-  labels:
-    {{- include "gpu-provisioner.labels" . | nindent 4 }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "gpu-provisioner.fullname" . }}
-  namespace:  {{ .Values.namespace }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     azure.workload.identity/use: "true"
     {{- include "gpu-provisioner.labels" . | nindent 4 }}

--- a/charts/kaito/gpu-provisioner/templates/role.yaml
+++ b/charts/kaito/gpu-provisioner/templates/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "gpu-provisioner.fullname" . }}
-  namespace:  {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}

--- a/charts/kaito/gpu-provisioner/templates/rolebinding.yaml
+++ b/charts/kaito/gpu-provisioner/templates/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "gpu-provisioner.fullname" . }}
-  namespace:  {{ .Values.namespace }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
@@ -16,7 +16,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: gpu-provisioner
-    namespace:  {{ .Values.namespace }}
+    namespace:  {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -36,4 +36,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: gpu-provisioner
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/kaito/gpu-provisioner/templates/serviceaccount.yaml
+++ b/charts/kaito/gpu-provisioner/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gpu-provisioner
-  namespace:  {{ .Values.namespace }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "gpu-provisioner.labels" . | nindent 4 }}
   annotations:

--- a/charts/kaito/gpu-provisioner/values.yaml
+++ b/charts/kaito/gpu-provisioner/values.yaml
@@ -1,4 +1,3 @@
-namespace: gpu-provisioner
 # -- Overrides the chart's name.
 nameOverride: ""
 # -- Overrides the chart's computed fullname.

--- a/charts/kaito/workspace/README.md
+++ b/charts/kaito/workspace/README.md
@@ -6,7 +6,9 @@
 export REGISTRY=<your_docker_registry>
 export IMG_NAME=workspace
 export IMG_TAG=0.2.1
-helm install workspace ./charts/kaito/workspace  --set image.repository=${REGISTRY}/$(IMG_NAME) --set image.tag=$(IMG_TAG)
+helm install workspace ./charts/kaito/workspace  \
+--set image.repository=${REGISTRY}/$(IMG_NAME) --set image.tag=$(IMG_TAG) \
+--namespace kaito-workspace --create-namespace
 ```
 
 ## Values

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -1,15 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ include "kaito.fullname" . }}
-  labels:
-    {{- include "kaito.labels" . | nindent 4 }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kaito.fullname" . }}
-  namespace: {{ include "kaito.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 spec:

--- a/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
+++ b/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nvidia-device-plugin-daemonset
-  namespace: {{ include "kaito.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 spec:

--- a/charts/kaito/workspace/templates/role.yaml
+++ b/charts/kaito/workspace/templates/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "kaito.fullname" . }}-role
-  namespace: {{ include "kaito.fullname" .}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 rules:

--- a/charts/kaito/workspace/templates/role_binding.yaml
+++ b/charts/kaito/workspace/templates/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "kaito.fullname" . }}-rolebinding
-  namespace: {{ include "kaito.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
    {{- include "kaito.labels" . | nindent 4 }}
 roleRef:

--- a/charts/kaito/workspace/templates/secret-webhook-cert.yaml
+++ b/charts/kaito/workspace/templates/secret-webhook-cert.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: workspace-webhook-cert
-  namespace: {{ include "kaito.fullname" .}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 data:

--- a/charts/kaito/workspace/templates/service.yaml
+++ b/charts/kaito/workspace/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kaito.fullname" . }}
-  namespace: {{ include "kaito.fullname" .}}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 spec:

--- a/charts/kaito/workspace/templates/serviceaccount.yaml
+++ b/charts/kaito/workspace/templates/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kaito.fullname" . }}-sa
-  namespace: {{ include "kaito.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ az aks install-cli
 Install the Workspace controller.
 
 ```bash
-helm install workspace ./charts/kaito/workspace
+helm install workspace ./charts/kaito/workspace --namespace kaito-workspace --create-namespace
 ```
 
 Note that if you have installed another node provisioning controller that supports Karpenter-core APIs, the following steps for installing `gpu-provisioner` can be skipped.
@@ -105,7 +105,8 @@ settings:
 EOF
 
 # install gpu-provisioner using values override file
-helm install gpu-provisioner ./charts/kaito/gpu-provisioner -f values.override.yaml
+helm install gpu-provisioner ./charts/kaito/gpu-provisioner \
+--namespace gpu-provisioner --create-namespace -f values.override.yaml
 ```
 
 #### Create the federated credential


### PR DESCRIPTION
**Reason for Change**:
Update helm chart to use `Release.Namespace` instead of chart name.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: