### PR TITLE
fix: Add registry as a pipeline job output

### DIFF
--- a/.github/workflows/publish-gh-image.yml
+++ b/.github/workflows/publish-gh-image.yml
@@ -115,7 +115,7 @@ jobs:
     with:
       git_sha: ${{ github.sha }}
       isRelease: true
-      registry: ${{ needs.get-registry.outputs.registry_repository }}
+      registry: ${{ needs.build-scan-publish-gh-images.outputs.registry_repository }}
       tag: ${{ needs.check-tag.outputs.tag }}
     secrets:
       E2E_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/publish-gh-image.yml
+++ b/.github/workflows/publish-gh-image.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ check-tag ]
     environment: preset-env
+    outputs:
+      registry_repository: ${{ steps.get-registry.outputs.registry_repository }}
     steps:
       - id: get-registry
         run: |


### PR DESCRIPTION
**Reason for Change**:
- The job output for registry was missing.
- calling the output should use the job name, not step one.
- 
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: