### PR TITLE
docs: update workspace install namespace

### DIFF
--- a/charts/kaito/workspace/README.md
+++ b/charts/kaito/workspace/README.md
@@ -8,7 +8,7 @@ export IMG_NAME=workspace
 export IMG_TAG=0.2.2
 helm install workspace ./charts/kaito/workspace  \
 --set image.repository=${REGISTRY}/$(IMG_NAME) --set image.tag=$(IMG_TAG) \
---namespace kaito-workspace --create-namespace
+--namespace workspace --create-namespace
 ```
 
 ## Values

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ az aks install-cli
 Install the Workspace controller.
 
 ```bash
-helm install workspace ./charts/kaito/workspace --namespace kaito-workspace --create-namespace
+helm install workspace ./charts/kaito/workspace --namespace workspace --create-namespace
 ```
 
 Note that if you have installed another node provisioning controller that supports Karpenter-core APIs, the following steps for installing `gpu-provisioner` can be skipped.


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

If you install the the workspace controller to the `kaito-workspace` namespace as described in the docs, you get the following error when installing the workspace model (falcon-7b-instruct for example):

`Error from server (InternalError): error when creating "./kaito/falcon.yaml": Internal error occurred: failed calling webhook "validation.workspace.kaito.sh": failed to call webhook: Post "https://workspace.workspace.svc:9443/?timeout=10s": service "workspace" not found`

So this PR fixes the namespace for the workspace controller.
