### PR TITLE
feat: Add global client, accessible via webhooks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"flag"
 	"github.com/azure/kaito/pkg/k8sclient"
-	_ "knative.dev/pkg/system/testing"
 	"os"
 	"strconv"
 	"time"

--- a/pkg/k8sclient/client.go
+++ b/pkg/k8sclient/client.go
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package k8sclient
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var Client client.Client
+
+func SetGlobalClient(c client.Client) {
+	Client = c
+}
+
+func GetGlobalClient() client.Client {
+	return Client
+}


### PR DESCRIPTION
**Reason for Change**:
Add global client, accessible via webhooks

In this PR I also
Separate setup and execution phase of webhook server, allows us to handle setup errors and setup context before attempting to run the webhook server

