### PR TITLE
feat: Setup Preset Tuning Util Functions and miscellaneous validation/logging - Part 7

### DIFF
--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -163,6 +163,12 @@ func (r *DataSource) validateCreate() (errs *apis.FieldError) {
 		sourcesSpecified++
 	}
 	if r.Image != "" {
+		if !strings.Contains(r.Image, ":") {
+			klog.Infof("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
+		}
+		if !strings.Contains(r.Image, "/") {
+			klog.Warningf("Input image specification may be incomplete or incorrect: %s. A complete image URL is recommended.", r.Image)
+		}
 		sourcesSpecified++
 	}
 
@@ -216,6 +222,9 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 	if r.Image != "" {
 		if !strings.Contains(r.Image, ":") {
 			klog.Infof("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
+		}
+		if !strings.Contains(r.Image, "/") {
+			klog.Warningf("Output image specification may be incomplete or incorrect: %s. A complete image URL is recommended.", r.Image)
 		}
 		// Cloud Provider requires credentials to push image
 		if r.ImagePushSecret == "" {

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -214,6 +214,10 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 		destinationsSpecified++
 	}
 	if r.Image != "" {
+		// Cloud Provider requires credentials to push image
+		if r.ImagePushSecret == "" {
+			errs = errs.Also(apis.ErrMissingField("Must specify imagePushSecret with destination image"))
+		}
 		destinationsSpecified++
 	}
 

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -214,6 +214,9 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 		destinationsSpecified++
 	}
 	if r.Image != "" {
+		if !strings.Contains(r.Image, ":") {
+			klog.Info("Tag not specified for image destination, default `latest` tag being used", r.Image)
+		}
 		// Cloud Provider requires credentials to push image
 		if r.ImagePushSecret == "" {
 			errs = errs.Also(apis.ErrMissingField("Must specify imagePushSecret with destination image"))

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -164,7 +164,7 @@ func (r *DataSource) validateCreate() (errs *apis.FieldError) {
 	}
 	if r.Image != "" {
 		if !strings.Contains(r.Image, ":") {
-			klog.Infof("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
+			klog.Warningf("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
 		}
 		if !strings.Contains(r.Image, "/") {
 			klog.Warningf("Input image specification may be incomplete or incorrect: %s. A complete image URL is recommended.", r.Image)
@@ -221,7 +221,7 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 	}
 	if r.Image != "" {
 		if !strings.Contains(r.Image, ":") {
-			klog.Infof("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
+			klog.Warningf("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
 		}
 		if !strings.Contains(r.Image, "/") {
 			klog.Warningf("Output image specification may be incomplete or incorrect: %s. A complete image URL is recommended.", r.Image)

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -215,7 +215,7 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 	}
 	if r.Image != "" {
 		if !strings.Contains(r.Image, ":") {
-			klog.Info("Tag not specified for image destination, default `latest` tag being used", r.Image)
+			klog.Infof("Tag not specified for image destination (%s), defaulting to 'latest' tag.", r.Image)
 		}
 		// Cloud Provider requires credentials to push image
 		if r.ImagePushSecret == "" {

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -889,7 +889,7 @@ func TestDataSourceValidateCreate(t *testing.T) {
 		{
 			name: "Image specified only",
 			dataSource: &DataSource{
-				Image: "data-image:latest",
+				Image: "aimodels.azurecr.io/data-image:latest",
 			},
 			wantErr: false,
 		},
@@ -913,7 +913,7 @@ func TestDataSourceValidateCreate(t *testing.T) {
 			dataSource: &DataSource{
 				URLs:   []string{"http://example.com/data"},
 				Volume: &v1.VolumeSource{},
-				Image:  "data-image:latest",
+				Image:  "aimodels.azurecr.io/data-image:latest",
 			},
 			wantErr:  true,
 			errField: "Exactly one of URLs, Volume, or Image must be specified",
@@ -1049,7 +1049,7 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 		{
 			name: "Image specified only",
 			dataDestination: &DataDestination{
-				Image: "data-image:latest",
+				Image: "aimodels.azurecr.io/data-image:latest",
 				ImagePushSecret: "imagePushSecret",
 			},
 			wantErr: false,
@@ -1058,7 +1058,7 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 			name: "Both fields specified",
 			dataDestination: &DataDestination{
 				Volume: &v1.VolumeSource{},
-				Image:  "data-image:latest",
+				Image:  "aimodels.azurecr.io/data-image:latest",
 				ImagePushSecret: "imagePushSecret",
 			},
 			wantErr: false,

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -1050,6 +1050,7 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 			name: "Image specified only",
 			dataDestination: &DataDestination{
 				Image: "data-image:latest",
+				ImagePushSecret: "imagePushSecret",
 			},
 			wantErr: false,
 		},

--- a/charts/kaito/workspace/templates/clusterrole.yaml
+++ b/charts/kaito/workspace/templates/clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
     verbs: ["get","list","watch","create", "update", "patch" ]
   - apiGroups: [ "" ]
     resources: [ "configmaps" ]
-    verbs: [ "get","list","watch" ]
+    verbs: [ "get","list","watch","create", "delete" ]
   - apiGroups: ["apps"]
     resources: ["daemonsets"]
     verbs: ["get","list","watch","update", "patch"]

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -22,6 +23,8 @@ func CreateResource(ctx context.Context, resource client.Object, kubeClient clie
 		klog.InfoS("CreateStatefulSet", "statefulset", klog.KObj(r))
 	case *corev1.Service:
 		klog.InfoS("CreateService", "service", klog.KObj(r))
+	case *corev1.ConfigMap:
+		klog.InfoS("CreateConfigMap", "configmap", klog.KObj(r))
 	}
 
 	// Create the resource.
@@ -74,6 +77,11 @@ func CheckResourceStatus(obj client.Object, kubeClient client.Client, timeoutDur
 			case *appsv1.StatefulSet:
 				if k8sResource.Status.ReadyReplicas == *k8sResource.Spec.Replicas {
 					klog.InfoS("statefulset status is ready", "statefulset", k8sResource.Name)
+					return nil
+				}
+			case *batchv1.Job:
+				klog.InfoS("checking job status", "name", k8sResource.Name, "namespace", k8sResource.Namespace, "succeeded", k8sResource.Status.Succeeded, "active", k8sResource.Status.Active, "failed", k8sResource.Status.Failed)
+				if k8sResource.Status.Failed == 0 {
 					return nil
 				}
 			default:

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -15,13 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// func getInstanceGPUCount(sku string) int {
-// 	gpuConfig, exists := kaitov1alpha1.SupportedGPUConfigs[sku]
-// 	if !exists {
-// 		return 1
-// 	}
-// 	return gpuConfig.GPUCount
-// }
+func GetInstanceGPUCount(sku string) int {
+	gpuConfig, exists := kaitov1alpha1.SupportedGPUConfigs[sku]
+	if !exists {
+		return 1
+	}
+	return gpuConfig.GPUCount
+}
 
 func GetTuningImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace, presetObj *model.PresetParam) string {
 	registryName := os.Getenv("PRESET_REGISTRY_NAME")

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -15,13 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getInstanceGPUCount(sku string) int {
-	gpuConfig, exists := kaitov1alpha1.SupportedGPUConfigs[sku]
-	if !exists {
-		return 1
-	}
-	return gpuConfig.GPUCount
-}
+// func getInstanceGPUCount(sku string) int {
+// 	gpuConfig, exists := kaitov1alpha1.SupportedGPUConfigs[sku]
+// 	if !exists {
+// 		return 1
+// 	}
+// 	return gpuConfig.GPUCount
+// }
 
 func GetTuningImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace, presetObj *model.PresetParam) string {
 	registryName := os.Getenv("PRESET_REGISTRY_NAME")

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -2,10 +2,141 @@ package tuning
 
 import (
 	"context"
+	"fmt"
+	"os"
+
 	kaitov1alpha1 "github.com/azure/kaito/api/v1alpha1"
 	"github.com/azure/kaito/pkg/model"
+	"github.com/azure/kaito/pkg/resources"
+	"github.com/azure/kaito/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	ProbePath  = "/healthz"
+	Port5000   = int32(5000)
+	TuningFile = "fine_tuning_api.py"
+)
+
+var (
+	containerPorts = []corev1.ContainerPort{{
+		ContainerPort: Port5000,
+	},
+	}
+
+	livenessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(5000),
+				Path: ProbePath,
+			},
+		},
+		InitialDelaySeconds: 600, // 10 minutes
+		PeriodSeconds:       10,
+	}
+
+	readinessProbe = &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Port: intstr.FromInt(5000),
+				Path: ProbePath,
+			},
+		},
+		InitialDelaySeconds: 30,
+		PeriodSeconds:       10,
+	}
+
+	tolerations = []corev1.Toleration{
+		{
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpEqual,
+			Key:      resources.GPUString,
+		},
+		{
+			Effect: corev1.TaintEffectNoSchedule,
+			Value:  resources.GPUString,
+			Key:    "sku",
+		},
+	}
+)
+
+func getInstanceGPUCount(sku string) int {
+	gpuConfig, exists := kaitov1alpha1.SupportedGPUConfigs[sku]
+	if !exists {
+		return 1
+	}
+	return gpuConfig.GPUCount
+}
+
+func formatRegistryImagePath(registryName, imageName, imageTag string) string {
+	if imageTag != "" {
+		return fmt.Sprintf("%s/%s:%s", registryName, imageName, imageTag)
+	}
+	return fmt.Sprintf("%s/%s", registryName, imageName)
+}
+
+func GetTuningImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace, presetObj *model.PresetParam) string {
+	registryName := os.Getenv("PRESET_REGISTRY_NAME")
+	return formatRegistryImagePath(registryName, "kaito-tuning-"+string(wObj.Tuning.Preset.Name), presetObj.Tag)
+}
+
+func GetDataSrcImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace) (string, []corev1.LocalObjectReference) {
+	imagePullSecretRefs := make([]corev1.LocalObjectReference, len(wObj.Tuning.Input.ImagePullSecrets))
+	for i, secretName := range wObj.Tuning.Input.ImagePullSecrets {
+		imagePullSecretRefs[i] = corev1.LocalObjectReference{Name: secretName}
+	}
+	registryName := os.Getenv("PRESET_REGISTRY_NAME")
+	imageName := formatRegistryImagePath(registryName, wObj.Tuning.Input.Image, "")
+	return imageName, imagePullSecretRefs
+}
+
+func GetDataDestImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace) (string, []corev1.LocalObjectReference) {
+	registryName := os.Getenv("PRESET_REGISTRY_NAME")
+	imageName := fmt.Sprintf("%s/%s", registryName, wObj.Tuning.Output.Image)
+	imagePushSecretRefs := []corev1.LocalObjectReference{{Name: wObj.Tuning.Output.ImagePushSecret}}
+	return imageName, imagePushSecretRefs
+}
+
+func CreatePresetConfigMap(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
+	tuningObj *model.PresetParam, kubeClient client.Client) error {
+	// Copy Configmap from helm chart configmap into workspace
+	releaseNamespace, err := utils.GetReleaseNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get release namespace: %v", err)
+	}
+	existingCM := &corev1.ConfigMap{}
+	err = resources.GetResource(ctx, workspaceObj.Tuning.ConfigTemplate, workspaceObj.Namespace, kubeClient, existingCM)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		klog.Info("ConfigMap already exists in target namespace: %s, no action taken.\n", workspaceObj.Namespace)
+		return nil
+	}
+
+	templateCM := &corev1.ConfigMap{}
+	err = resources.GetResource(ctx, workspaceObj.Tuning.ConfigTemplate, releaseNamespace, kubeClient, templateCM)
+	if err != nil {
+		return fmt.Errorf("failed to get ConfigMap from template namespace: %v", err)
+	}
+
+	templateCM.Namespace = workspaceObj.Namespace
+	templateCM.ResourceVersion = "" // Clear metadata not needed for creation
+	templateCM.UID = ""             // Clear UID
+
+	// TODO: Any Custom Preset override logic for the configmap can go here
+	err = resources.CreateResource(ctx, templateCM, kubeClient)
+	if err != nil {
+		return fmt.Errorf("failed to create ConfigMap in target namespace, %s: %v", workspaceObj.Namespace, err)
+	}
+
+	return nil
+}
 
 func CreatePresetTuning(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
 	tuningObj *model.PresetParam, kubeClient client.Client) (client.Object, error) {

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -11,57 +11,8 @@ import (
 	"github.com/azure/kaito/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	ProbePath  = "/healthz"
-	Port5000   = int32(5000)
-	TuningFile = "fine_tuning_api.py"
-)
-
-var (
-	containerPorts = []corev1.ContainerPort{{
-		ContainerPort: Port5000,
-	},
-	}
-
-	livenessProbe = &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port: intstr.FromInt(5000),
-				Path: ProbePath,
-			},
-		},
-		InitialDelaySeconds: 600, // 10 minutes
-		PeriodSeconds:       10,
-	}
-
-	readinessProbe = &corev1.Probe{
-		ProbeHandler: corev1.ProbeHandler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Port: intstr.FromInt(5000),
-				Path: ProbePath,
-			},
-		},
-		InitialDelaySeconds: 30,
-		PeriodSeconds:       10,
-	}
-
-	tolerations = []corev1.Toleration{
-		{
-			Effect:   corev1.TaintEffectNoSchedule,
-			Operator: corev1.TolerationOpEqual,
-			Key:      resources.GPUString,
-		},
-		{
-			Effect: corev1.TaintEffectNoSchedule,
-			Value:  resources.GPUString,
-			Key:    "sku",
-		},
-	}
 )
 
 func getInstanceGPUCount(sku string) int {
@@ -72,16 +23,9 @@ func getInstanceGPUCount(sku string) int {
 	return gpuConfig.GPUCount
 }
 
-func formatRegistryImagePath(registryName, imageName, imageTag string) string {
-	if imageTag != "" {
-		return fmt.Sprintf("%s/%s:%s", registryName, imageName, imageTag)
-	}
-	return fmt.Sprintf("%s/%s", registryName, imageName)
-}
-
 func GetTuningImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace, presetObj *model.PresetParam) string {
 	registryName := os.Getenv("PRESET_REGISTRY_NAME")
-	return formatRegistryImagePath(registryName, "kaito-tuning-"+string(wObj.Tuning.Preset.Name), presetObj.Tag)
+	return fmt.Sprintf("%s/%s:%s", registryName, "kaito-tuning-"+string(wObj.Tuning.Preset.Name), presetObj.Tag)
 }
 
 func GetDataSrcImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace) (string, []corev1.LocalObjectReference) {
@@ -89,19 +33,15 @@ func GetDataSrcImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace) (st
 	for i, secretName := range wObj.Tuning.Input.ImagePullSecrets {
 		imagePullSecretRefs[i] = corev1.LocalObjectReference{Name: secretName}
 	}
-	registryName := os.Getenv("PRESET_REGISTRY_NAME")
-	imageName := formatRegistryImagePath(registryName, wObj.Tuning.Input.Image, "")
-	return imageName, imagePullSecretRefs
+	return wObj.Tuning.Input.Image, imagePullSecretRefs
 }
 
 func GetDataDestImageInfo(ctx context.Context, wObj *kaitov1alpha1.Workspace) (string, []corev1.LocalObjectReference) {
-	registryName := os.Getenv("PRESET_REGISTRY_NAME")
-	imageName := fmt.Sprintf("%s/%s", registryName, wObj.Tuning.Output.Image)
 	imagePushSecretRefs := []corev1.LocalObjectReference{{Name: wObj.Tuning.Output.ImagePushSecret}}
-	return imageName, imagePushSecretRefs
+	return wObj.Tuning.Output.Image, imagePushSecretRefs
 }
 
-func CreatePresetConfigMap(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
+func EnsureTuningConfigMap(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
 	tuningObj *model.PresetParam, kubeClient client.Client) error {
 	// Copy Configmap from helm chart configmap into workspace
 	releaseNamespace, err := utils.GetReleaseNamespace()


### PR DESCRIPTION
**Reason for Change**:
This PR introduces some of the util functions that are to be used by the function

func CreatePresetTuning(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
	tuningObj *model.PresetParam, kubeClient client.Client) (client.Object, error)
	

This function will be in charge of handling launching the training job using the dataset source and uploading results to dataset destination. It is also incharge of ensuring configmap tuning parameters are in the right namespace so they are ready to be used by the fine_tuning_api.py file. 
	
	