### PR TITLE
feat: Support Karpenter NodeClaim API in workspace

### DIFF
--- a/api/v1alpha1/workspace_condition_types.go
+++ b/api/v1alpha1/workspace_condition_types.go
@@ -10,6 +10,9 @@ const (
 	// WorkspaceConditionTypeMachineStatus is the state when checking machine status.
 	WorkspaceConditionTypeMachineStatus = ConditionType("MachineReady")
 
+	// WorkspaceConditionTypeNodeClaimStatus is the state when checking nodeClaim status.
+	WorkspaceConditionTypeNodeClaimStatus = ConditionType("NodeClaimReady")
+
 	// WorkspaceConditionTypeResourceStatus is the state when Resource has been created.
 	WorkspaceConditionTypeResourceStatus = ConditionType("ResourceReady")
 

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -9,9 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/azure/kaito/pkg/nodeclaim"
 	"github.com/azure/kaito/pkg/tuning"
 	"github.com/azure/kaito/pkg/utils/consts"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	kaitov1alpha1 "github.com/azure/kaito/api/v1alpha1"
@@ -46,9 +50,10 @@ const (
 
 type WorkspaceReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	Recorder          record.EventRecorder
+	KubernetesVersion *version.Info
 }
 
 func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -61,6 +66,18 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	}
 
 	klog.InfoS("Reconciling", "workspace", req.NamespacedName)
+
+	// Get the current API Server version.
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		klog.ErrorS(err, "unable to create discovery client")
+		return reconcile.Result{}, err
+	}
+	c.KubernetesVersion, err = discoveryClient.ServerVersion()
+	if err != nil {
+		klog.ErrorS(err, "unable to get k8s version")
+		return reconcile.Result{}, err
+	}
 
 	// Handle deleting workspace, garbage collect all the resources.
 	if !workspaceObj.DeletionTimestamp.IsZero() {
@@ -80,7 +97,7 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	if workspaceObj.Inference != nil && workspaceObj.Inference.Preset != nil {
 		if !plugin.KaitoModelRegister.Has(string(workspaceObj.Inference.Preset.Name)) {
-			return reconcile.Result{}, fmt.Errorf("The preset model name %s is not registered for workspace %s/%s", string(workspaceObj.Inference.Preset.Name), workspaceObj.Namespace, workspaceObj.Name)
+			return reconcile.Result{}, fmt.Errorf("the preset model name %s is not registered for workspace %s/%s", string(workspaceObj.Inference.Preset.Name), workspaceObj.Namespace, workspaceObj.Name)
 		}
 	}
 
@@ -96,8 +113,9 @@ func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *ka
 			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
 			return reconcile.Result{}, updateErr
 		}
-		// if error is	due to machine instance types unavailability, stop reconcile.
-		if err.Error() == machine.ErrorInstanceTypesUnavailable {
+		// if error is	due to machine/nodeClaim instance types unavailability, stop reconcile.
+		if err.Error() == machine.ErrorInstanceTypesUnavailable ||
+			err.Error() == nodeclaim.ErrorInstanceTypesUnavailable {
 			return reconcile.Result{Requeue: false}, err
 		}
 		return reconcile.Result{}, err
@@ -139,7 +157,6 @@ func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *ka
 
 func (c *WorkspaceReconciler) deleteWorkspace(ctx context.Context, wObj *kaitov1alpha1.Workspace) (reconcile.Result, error) {
 	klog.InfoS("deleteWorkspace", "workspace", klog.KObj(wObj))
-	// TODO delete workspace, machine(s), fine_tuning and inference (deployment, service) obj ( ok to delete machines? which will delete nodes??)
 	err := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeDeleting, metav1.ConditionTrue, "workspaceDeleted", "workspace is being deleted")
 	if err != nil {
 		klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
@@ -149,7 +166,7 @@ func (c *WorkspaceReconciler) deleteWorkspace(ctx context.Context, wObj *kaitov1
 	return c.garbageCollectWorkspace(ctx, wObj)
 }
 
-func selectWorkspaceNodes(qualified []*corev1.Node, preferred []string, previous []string, count int) []*corev1.Node {
+func (c *WorkspaceReconciler) selectWorkspaceNodes(qualified []*corev1.Node, preferred []string, previous []string, count int) []*corev1.Node {
 
 	sort.Slice(qualified, func(i, j int) bool {
 		iPreferred := utils.Contains(preferred, qualified[i].Name)
@@ -168,16 +185,27 @@ func selectWorkspaceNodes(qualified []*corev1.Node, preferred []string, previous
 			} else if !iPrevious && jPrevious {
 				return false
 			} else { // either all are previous, or none is previous
-				_, iCreatedByKaito := qualified[i].Labels["kaito.sh/machine-type"]
-				_, jCreatedByKaito := qualified[j].Labels["kaito.sh/machine-type"]
-
+				var iCreatedByGPUProvisioner, jCreatedByGPUProvisioner bool
+				_, iCreatedByGPUProvisioner = qualified[i].Labels[machine.LabelGPUProvisionerCustom]
+				_, jCreatedByGPUProvisioner = qualified[j].Labels[machine.LabelGPUProvisionerCustom]
 				// Choose node created by gpu-provisioner since it is more likely to be empty to use.
-				if iCreatedByKaito && !jCreatedByKaito {
+				if iCreatedByGPUProvisioner && !jCreatedByGPUProvisioner {
 					return true
-				} else if !iCreatedByKaito && jCreatedByKaito {
+				} else if !iCreatedByGPUProvisioner && jCreatedByGPUProvisioner {
 					return false
 				} else {
-					return qualified[i].Name < qualified[j].Name
+					var iCreatedByKarpenter, jCreatedByKarpenter bool
+					_, iCreatedByKarpenter = qualified[i].Labels[nodeclaim.LabelNodePool]
+					_, jCreatedByKarpenter = qualified[j].Labels[nodeclaim.LabelNodePool]
+
+					// Choose node created by karpenter since it is more likely to be empty to use.
+					if iCreatedByKarpenter && !jCreatedByKarpenter {
+						return true
+					} else if !iCreatedByKarpenter && jCreatedByKarpenter {
+						return false
+					} else {
+						return qualified[i].Name < qualified[j].Name
+					}
 				}
 			}
 		}
@@ -185,8 +213,8 @@ func selectWorkspaceNodes(qualified []*corev1.Node, preferred []string, previous
 
 	if len(qualified) <= count {
 		return qualified
-
 	}
+
 	return qualified[0:count]
 }
 
@@ -197,23 +225,38 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 	if err := machine.WaitForPendingMachines(ctx, wObj, c.Client); err != nil {
 		return err
 	}
+	// Check nodeClaims only if the k8s version is greater than 1.29. As nodeClaim is supported from 1.29.
+	if c.KubernetesVersion.Major >= "29" {
+		// Wait for pending nodeClaims if any before we decide whether to create new node or not.
+		if err := nodeclaim.WaitForPendingNodeClaims(ctx, wObj, c.Client); err != nil {
+			return err
+		}
+	}
 
-	// Find all nodes that match the labelSelector and instanceType, they are not necessarily created by machines.
+	// Find all nodes that match the labelSelector and instanceType, they are not necessarily created by machines/nodeClaims.
 	validNodes, err := c.getAllQualifiedNodes(ctx, wObj)
 	if err != nil {
 		return err
 	}
 
-	selectedNodes := selectWorkspaceNodes(validNodes, wObj.Resource.PreferredNodes, wObj.Status.WorkerNodes, lo.FromPtr(wObj.Resource.Count))
+	selectedNodes := c.selectWorkspaceNodes(validNodes, wObj.Resource.PreferredNodes, wObj.Status.WorkerNodes, lo.FromPtr(wObj.Resource.Count))
 
 	newNodesCount := lo.FromPtr(wObj.Resource.Count) - len(selectedNodes)
 
 	if newNodesCount > 0 {
 		klog.InfoS("need to create more nodes", "NodeCount", newNodesCount)
-		if err := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionUnknown,
-			"CreateMachinePending", fmt.Sprintf("creating %d machines", newNodesCount)); err != nil {
-			klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
-			return err
+		if c.KubernetesVersion.Major < "29" {
+			if err := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionUnknown,
+				"CreateMachinePending", fmt.Sprintf("creating %d machines", newNodesCount)); err != nil {
+				klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
+				return err
+			}
+		} else {
+			if err := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeNodeClaimStatus, metav1.ConditionUnknown,
+				"CreateNodeClaimPending", fmt.Sprintf("creating %d nodeClaims", newNodesCount)); err != nil {
+				klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
+				return err
+			}
 		}
 
 		for i := 0; i < newNodesCount; i++ {
@@ -245,10 +288,18 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 		}
 	}
 
-	if err = c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionTrue,
-		"installNodePluginsSuccess", "machines plugins have been installed successfully"); err != nil {
-		klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
-		return err
+	if c.KubernetesVersion.Major < "29" {
+		if err = c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionTrue,
+			"installNodePluginsSuccess", "machines plugins have been installed successfully"); err != nil {
+			klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
+			return err
+		}
+	} else {
+		if err = c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeNodeClaimStatus, metav1.ConditionTrue,
+			"installNodePluginsSuccess", "nodeClaim plugins have been installed successfully"); err != nil {
+			klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
+			return err
+		}
 	}
 
 	// Add the valid nodes names to the WorkspaceStatus.WorkerNodes.
@@ -314,24 +365,33 @@ func (c *WorkspaceReconciler) validateNodeInstanceType(ctx context.Context, wObj
 	return true
 }
 
-// createAndValidateNode creates a new machine and validates status.
+// createAndValidateNode creates a new node and validates status.
 func (c *WorkspaceReconciler) createAndValidateNode(ctx context.Context, wObj *kaitov1alpha1.Workspace) (*corev1.Node, error) {
-	var machineOSDiskSize string
+	var nodeOSDiskSize string
 	if wObj.Inference != nil && wObj.Inference.Preset != nil && wObj.Inference.Preset.Name != "" {
 		presetName := string(wObj.Inference.Preset.Name)
-		machineOSDiskSize = plugin.KaitoModelRegister.MustGet(presetName).GetInferenceParameters().DiskStorageRequirement
+		nodeOSDiskSize = plugin.KaitoModelRegister.MustGet(presetName).GetInferenceParameters().DiskStorageRequirement
 	}
-	if machineOSDiskSize == "" {
-		machineOSDiskSize = "0" // The default OS size is used
+	if nodeOSDiskSize == "" {
+		nodeOSDiskSize = "0" // The default OS size is used
 	}
 
-Retry_withdifferentname:
-	newMachine := machine.GenerateMachineManifest(ctx, machineOSDiskSize, wObj)
+	// If	the k8s version is less than 1.29, create machine, else create nodeClaim.
+	if c.KubernetesVersion.Major < "29" {
+		return c.CreateMachine(ctx, wObj, nodeOSDiskSize)
+	} else {
+		return c.CreateNodeClaim(ctx, wObj, nodeOSDiskSize)
+	}
+}
+
+func (c *WorkspaceReconciler) CreateMachine(ctx context.Context, wObj *kaitov1alpha1.Workspace, nodeOSDiskSize string) (*corev1.Node, error) {
+RetryWithDifferentName:
+	newMachine := machine.GenerateMachineManifest(ctx, nodeOSDiskSize, wObj)
 
 	if err := machine.CreateMachine(ctx, newMachine, c.Client); err != nil {
 		if apierrors.IsAlreadyExists(err) {
 			klog.InfoS("There exists a machine with the same name, retry with a different name", "machine", klog.KObj(newMachine))
-			goto Retry_withdifferentname
+			goto RetryWithDifferentName
 		} else {
 
 			klog.ErrorS(err, "failed to create machine", "machine", newMachine.Name)
@@ -357,6 +417,41 @@ Retry_withdifferentname:
 
 	// get the node object from the machine status nodeName.
 	return resources.GetNode(ctx, newMachine.Status.NodeName, c.Client)
+}
+
+func (c *WorkspaceReconciler) CreateNodeClaim(ctx context.Context, wObj *kaitov1alpha1.Workspace, nodeOSDiskSize string) (*corev1.Node, error) {
+RetryWithDifferentName:
+	newNodeClaim := nodeclaim.GenerateNodeClaimManifest(ctx, nodeOSDiskSize, wObj)
+
+	if err := nodeclaim.CreateNodeClaim(ctx, newNodeClaim, c.Client); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			klog.InfoS("There exists a nodeClaim with the same name, retry with a different name", "nodeClaim", klog.KObj(newNodeClaim))
+			goto RetryWithDifferentName
+		} else {
+
+			klog.ErrorS(err, "failed to create nodeClaim", "nodeClaim", newNodeClaim.Name)
+			if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeNodeClaimStatus, metav1.ConditionFalse,
+				"nodeClaimFailedCreation", err.Error()); updateErr != nil {
+				klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+				return nil, updateErr
+			}
+			return nil, err
+		}
+	}
+
+	// check nodeClaim status until it is ready
+	err := nodeclaim.CheckNodeClaimStatus(ctx, newNodeClaim, c.Client)
+	if err != nil {
+		if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeNodeClaimStatus, metav1.ConditionFalse,
+			"checkNodeClaimStatusFailed", err.Error()); updateErr != nil {
+			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+			return nil, updateErr
+		}
+		return nil, err
+	}
+
+	// get the node object from the nodeClaim status nodeName.
+	return resources.GetNode(ctx, newNodeClaim.Status.NodeName, c.Client)
 }
 
 // ensureNodePlugins ensures node plugins are installed.
@@ -523,7 +618,6 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 			return updateErr
 		} else {
 			return err
-
 		}
 	}
 
@@ -549,7 +643,8 @@ func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kaitov1alpha1.Workspace{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
-		Watches(&v1alpha5.Machine{}, c.watchMachines()).
+		Watches(&v1alpha5.Machine{}, c.watchMachines()). // watches for machine with labels indicating workspace name.
+		Watches(&v1beta1.NodeClaim{}, c.watchNodeClaims()). // watches for nodeClaim with labels indicating workspace name.
 		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
 		Complete(c)
 }
@@ -564,6 +659,30 @@ func (c *WorkspaceReconciler) watchMachines() handler.EventHandler {
 				return nil
 			}
 			namespace, ok := machineObj.Labels[kaitov1alpha1.LabelWorkspaceNamespace]
+			if !ok {
+				return nil
+			}
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Name:      name,
+						Namespace: namespace,
+					},
+				},
+			}
+		})
+}
+
+// watches for nodeClaim with labels indicating workspace name.
+func (c *WorkspaceReconciler) watchNodeClaims() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, o client.Object) []reconcile.Request {
+			nodeClaimObj := o.(*v1beta1.NodeClaim)
+			name, ok := nodeClaimObj.Labels[kaitov1alpha1.LabelWorkspaceName]
+			if !ok {
+				return nil
+			}
+			namespace, ok := nodeClaimObj.Labels[kaitov1alpha1.LabelWorkspaceNamespace]
 			if !ok {
 				return nil
 			}

--- a/pkg/controllers/workspace_gc_finalizer.go
+++ b/pkg/controllers/workspace_gc_finalizer.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 package controllers
 
 import (
@@ -33,8 +34,7 @@ func (c *WorkspaceReconciler) garbageCollectWorkspace(ctx context.Context, wObj 
 		}
 	}
 
-	if c.KubernetesVersion.Major >= consts.RequiredKubernetesVersionForNodeClaim &&
-		featuregates.FeatureGates[consts.FeatureFlagKarpenter] {
+	if featuregates.FeatureGates[consts.FeatureFlagKarpenter] {
 		// Check if there are any nodeClaims associated with this workspace.
 		ncList, err := nodeclaim.ListNodeClaimByWorkspace(ctx, wObj, c.Client)
 		if err != nil {

--- a/pkg/controllers/workspace_gc_finalizer.go
+++ b/pkg/controllers/workspace_gc_finalizer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 
 	kaitov1alpha1 "github.com/azure/kaito/api/v1alpha1"
+	"github.com/azure/kaito/pkg/featuregates"
 	"github.com/azure/kaito/pkg/machine"
 	"github.com/azure/kaito/pkg/nodeclaim"
 	"github.com/azure/kaito/pkg/utils/consts"
@@ -32,7 +33,8 @@ func (c *WorkspaceReconciler) garbageCollectWorkspace(ctx context.Context, wObj 
 		}
 	}
 
-	if c.KubernetesVersion.Major >= consts.RequiredKubernetesVersionForNodeClaim {
+	if c.KubernetesVersion.Major >= consts.RequiredKubernetesVersionForNodeClaim &&
+		featuregates.FeatureGates[consts.FeatureFlagKarpenter] {
 		// Check if there are any nodeClaims associated with this workspace.
 		ncList, err := nodeclaim.ListNodeClaimByWorkspace(ctx, wObj, c.Client)
 		if err != nil {

--- a/pkg/controllers/workspace_gc_finalizer.go
+++ b/pkg/controllers/workspace_gc_finalizer.go
@@ -32,7 +32,7 @@ func (c *WorkspaceReconciler) garbageCollectWorkspace(ctx context.Context, wObj 
 		}
 	}
 
-	if c.KubernetesVersion.Major >= "29" {
+	if c.KubernetesVersion.Major >= consts.RequiredKubernetesVersionForNodeClaim {
 		// Check if there are any nodeClaims associated with this workspace.
 		ncList, err := nodeclaim.ListNodeClaimByWorkspace(ctx, wObj, c.Client)
 		if err != nil {

--- a/pkg/controllers/workspace_gc_finalizer_test.go
+++ b/pkg/controllers/workspace_gc_finalizer_test.go
@@ -1,0 +1,266 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/azure/kaito/api/v1alpha1"
+	"github.com/azure/kaito/pkg/utils/test"
+	"github.com/stretchr/testify/mock"
+	"gotest.tools/assert"
+	"k8s.io/apimachinery/pkg/version"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
+)
+
+func TestGarbageCollectWorkspace(t *testing.T) {
+	testcases := map[string]struct {
+		callMocks     func(c *test.MockClient)
+		k8sVersion    *version.Info
+		expectedError error
+	}{
+		"Fails to delete workspace because associated machines cannot be retrieved": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(errors.New("failed to list machines"))
+			},
+			k8sVersion:    &version.Info{Major: "27"},
+			expectedError: errors.New("failed to list machines"),
+		},
+		"Fails to delete workspace because associated machines cannot be deleted": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				machineList := test.MockMachineList
+				relevantMap := c.CreateMapWithType(machineList)
+				//insert machine objects into the map
+				for _, obj := range test.MockMachineList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(errors.New("failed to delete machine"))
+
+			},
+			expectedError: errors.New("failed to delete machine"),
+		},
+		"Fails to delete workspace because associated nodeClaims cannot be retrieved": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(errors.New("failed to list nodeClaims"))
+			},
+			k8sVersion:    &version.Info{Major: "29"},
+			expectedError: errors.New("failed to list nodeClaims"),
+		},
+		"Fails to delete workspace because associated nodeClaims cannot be deleted": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				nodeClaimList := test.MockNodeClaimList
+				relevantMap := c.CreateMapWithType(nodeClaimList)
+				//insert nodeClaim objects into the map
+				for _, obj := range nodeClaimList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaim{}), mock.Anything).Return(errors.New("failed to delete nodeClaim"))
+
+			},
+			k8sVersion:    &version.Info{Major: "29"},
+			expectedError: errors.New("failed to delete nodeClaim"),
+		},
+		"Delete workspace with associated machine objects because finalizer cannot be removed from workspace": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(errors.New("failed to update workspace"))
+
+				machineList := test.MockMachineList
+				relevantMap := c.CreateMapWithType(machineList)
+				//insert machine objects into the map
+				for _, obj := range machineList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(nil)
+			},
+			k8sVersion:    &version.Info{Major: "27"},
+			expectedError: errors.New("failed to update workspace"),
+		},
+		"Successfully deletes workspace with associated machine objects and removes finalizer associated with workspace": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				machineList := test.MockMachineList
+				relevantMap := c.CreateMapWithType(machineList)
+				//insert machine objects into the map
+				for _, obj := range test.MockMachineList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(nil)
+			},
+			k8sVersion:    &version.Info{Major: "27"},
+			expectedError: nil,
+		},
+		"Delete workspace with associated nodeClaim objects because finalizer cannot be removed from workspace": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(errors.New("failed to update workspace"))
+
+				nodeClaimList := test.MockNodeClaimList
+				relevantMap := c.CreateMapWithType(nodeClaimList)
+				//insert nodeClaim objects into the map
+				for _, obj := range nodeClaimList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaim{}), mock.Anything).Return(nil)
+			},
+			k8sVersion:    &version.Info{Major: "29"},
+			expectedError: errors.New("failed to update workspace"),
+		},
+		"Successfully deletes workspace with associated nodeClaim objects and removes finalizer associated with workspace": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(nil)
+
+				nodeClaimList := test.MockNodeClaimList
+				relevantMap := c.CreateMapWithType(nodeClaimList)
+				//insert nodeClaim objects into the map
+				for _, obj := range nodeClaimList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaim{}), mock.Anything).Return(nil)
+			},
+			k8sVersion:    &version.Info{Major: "29"},
+			expectedError: nil,
+		},
+		"Delete workspace with machine and nodeClaim objects because finalizer cannot be removed from workspace": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(errors.New("failed to update workspace"))
+
+				machineList := test.MockMachineList
+				relevantMachinesMap := c.CreateMapWithType(machineList)
+				//insert machine objects into the map
+				for _, obj := range machineList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMachinesMap[objKey] = &m
+				}
+				nodeClaimList := test.MockNodeClaimList
+				relevantNodeClaimsMap := c.CreateMapWithType(nodeClaimList)
+				//insert nodeClaim objects into the map
+				for _, obj := range nodeClaimList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantNodeClaimsMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaim{}), mock.Anything).Return(nil)
+			},
+			k8sVersion:    &version.Info{Major: "29"},
+			expectedError: errors.New("failed to update workspace"),
+		},
+		"Successfully deletes workspace with machine and nodeClaim objects and removes finalizer associated with workspace": {
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+
+				machineList := test.MockMachineList
+				relevantMachinesMap := c.CreateMapWithType(machineList)
+				//insert machine objects into the map
+				for _, obj := range machineList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantMachinesMap[objKey] = &m
+				}
+				nodeClaimList := test.MockNodeClaimList
+				relevantNodeClaimsMap := c.CreateMapWithType(nodeClaimList)
+				//insert nodeClaim objects into the map
+				for _, obj := range nodeClaimList.Items {
+					m := obj
+					objKey := client.ObjectKeyFromObject(&m)
+
+					relevantNodeClaimsMap[objKey] = &m
+				}
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaimList{}), mock.Anything).Return(nil)
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&v1beta1.NodeClaim{}), mock.Anything).Return(nil)
+			},
+			k8sVersion:    &version.Info{Major: "29"},
+			expectedError: nil,
+		},
+	}
+
+	for k, tc := range testcases {
+		t.Run(k, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tc.callMocks(mockClient)
+
+			reconciler := &WorkspaceReconciler{
+				Client:            mockClient,
+				Scheme:            test.NewTestScheme(),
+				KubernetesVersion: tc.k8sVersion,
+			}
+			ctx := context.Background()
+
+			_, err := reconciler.garbageCollectWorkspace(ctx, test.MockWorkspaceDistributedModel)
+			if tc.expectedError == nil {
+				assert.Check(t, err == nil, "Not expected to return error")
+			} else {
+				assert.Equal(t, tc.expectedError.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/pkg/controllers/workspace_status.go
+++ b/pkg/controllers/workspace_status.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 package controllers
 
 import (

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 package machine
 
 import (
@@ -162,7 +163,7 @@ func WaitForPendingMachines(ctx context.Context, workspaceObj *kaitov1alpha1.Wor
 	return nil
 }
 
-// ListMachines list all machine objects in the cluster that are created by the workspace identified by the label.
+// ListMachinesByWorkspace list all machine objects in the cluster that are created by the workspace identified by the label.
 func ListMachinesByWorkspace(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace, kubeClient client.Client) (*v1alpha5.MachineList, error) {
 	machineList := &v1alpha5.MachineList{}
 

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -5,8 +5,9 @@ package machine
 import (
 	"context"
 	"errors"
-	"github.com/azure/kaito/pkg/utils/test"
 	"testing"
+
+	"github.com/azure/kaito/pkg/utils/test"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/stretchr/testify/mock"
@@ -25,9 +26,9 @@ func TestCreateMachine(t *testing.T) {
 	}{
 		"Machine creation fails": {
 			callMocks: func(c *test.MockClient) {
-				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(errors.New("Failed to create machine"))
+				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(errors.New("failed to create machine"))
 			},
-			expectedError: errors.New("Failed to create machine"),
+			expectedError: errors.New("failed to create machine"),
 		},
 		"Machine creation fails because SKU is not available": {
 			callMocks: func(c *test.MockClient) {
@@ -84,9 +85,9 @@ func TestWaitForPendingMachines(t *testing.T) {
 	}{
 		"Fail to list machines because associated machines cannot be retrieved": {
 			callMocks: func(c *test.MockClient) {
-				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(errors.New("Failed to retrieve machines"))
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(errors.New("failed to retrieve machines"))
 			},
-			expectedError: errors.New("Failed to retrieve machines"),
+			expectedError: errors.New("failed to retrieve machines"),
 		},
 		"Fail to list machines because machine status cannot be retrieved": {
 			callMocks: func(c *test.MockClient) {
@@ -103,7 +104,7 @@ func TestWaitForPendingMachines(t *testing.T) {
 				}
 
 				c.On("List", mock.IsType(context.Background()), mock.IsType(&v1alpha5.MachineList{}), mock.Anything).Return(nil)
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(errors.New("Fail to get machine"))
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha5.Machine{}), mock.Anything).Return(errors.New("fail to get machine"))
 			},
 			machineConditions: apis.Conditions{
 				{
@@ -111,7 +112,7 @@ func TestWaitForPendingMachines(t *testing.T) {
 					Status: corev1.ConditionFalse,
 				},
 			},
-			expectedError: errors.New("Fail to get machine"),
+			expectedError: errors.New("fail to get machine"),
 		},
 		"Successfully waits for all pending machines": {
 			callMocks: func(c *test.MockClient) {
@@ -163,7 +164,7 @@ func TestWaitForPendingMachines(t *testing.T) {
 	}
 }
 
-func TestGenerateMachineManifiest(t *testing.T) {
+func TestGenerateMachineManifest(t *testing.T) {
 	t.Run("Should generate a machine object from the given workspace", func(t *testing.T) {
 		mockWorkspace := test.MockWorkspaceWithPreset
 

--- a/pkg/nodeclaim/nodeclaim.go
+++ b/pkg/nodeclaim/nodeclaim.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 package nodeclaim
 
 import (
@@ -24,10 +25,8 @@ import (
 )
 
 const (
-	NodePoolName                  = "default"
-	LabelGPUProvisionerCustom     = "kaito.sh/nodeclaim-type"
-	LabelNodePoolName             = "karpenter.sh/nodepool-name"
-	GPUString                     = "gpu"
+	KaitoNodePoolName             = "kaito"
+	LabelNodePool                 = "karpenter.sh/nodepool"
 	ErrorInstanceTypesUnavailable = "all requested instance types were unavailable during launch"
 )
 
@@ -41,7 +40,7 @@ func GenerateNodeClaimManifest(ctx context.Context, storageRequirement string, w
 	digest := sha256.Sum256([]byte(workspaceObj.Namespace + workspaceObj.Name + time.Now().Format("2006-01-02 15:04:05.000000000"))) // We make sure the nodeClaim name is not fixed to the a workspace
 	nodeClaimName := "ws" + hex.EncodeToString(digest[0:])[0:9]
 	nodeClaimLabels := map[string]string{
-		LabelNodePoolName:                     NodePoolName,
+		LabelNodePool:                         KaitoNodePoolName,
 		kaitov1alpha1.LabelWorkspaceName:      workspaceObj.Name,
 		kaitov1alpha1.LabelWorkspaceNamespace: workspaceObj.Namespace,
 	}
@@ -69,17 +68,9 @@ func GenerateNodeClaimManifest(ctx context.Context, storageRequirement string, w
 				},
 				{
 					NodeSelectorRequirement: v1.NodeSelectorRequirement{
-						Key:      LabelNodePoolName,
+						Key:      LabelNodePool,
 						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{NodePoolName},
-					},
-					MinValues: lo.ToPtr(1),
-				},
-				{
-					NodeSelectorRequirement: v1.NodeSelectorRequirement{
-						Key:      LabelGPUProvisionerCustom,
-						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{GPUString},
+						Values:   []string{KaitoNodePoolName},
 					},
 					MinValues: lo.ToPtr(1),
 				},
@@ -103,7 +94,7 @@ func GenerateNodeClaimManifest(ctx context.Context, storageRequirement string, w
 			Taints: []v1.Taint{
 				{
 					Key:    "sku",
-					Value:  GPUString,
+					Value:  "gpu",
 					Effect: v1.TaintEffectNoSchedule,
 				},
 			},

--- a/pkg/resources/manifests.go
+++ b/pkg/resources/manifests.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 package resources
 
 import (
@@ -48,7 +49,7 @@ func GenerateHeadlessServiceManifest(ctx context.Context, workspaceObj *kaitov1a
 					Name:       "torchrun",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       29500,
-					TargetPort: intstr.FromInt(29500),
+					TargetPort: intstr.FromInt32(29500),
 				},
 			},
 			PublishNotReadyAddresses: true,
@@ -88,14 +89,14 @@ func GenerateServiceManifest(ctx context.Context, workspaceObj *kaitov1alpha1.Wo
 					Name:       "http",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       80,
-					TargetPort: intstr.FromInt(5000),
+					TargetPort: intstr.FromInt32(5000),
 				},
 				// Torch NCCL Port
 				{
 					Name:       "torch",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       29500,
-					TargetPort: intstr.FromInt(29500),
+					TargetPort: intstr.FromInt32(29500),
 				},
 			},
 			Selector: selector,

--- a/pkg/resources/nodes.go
+++ b/pkg/resources/nodes.go
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 package resources
 
 import (

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -9,6 +9,6 @@ const (
 	DefaultReleaseNamespaceEnvVar = "RELEASE_NAMESPACE"
 	FeatureFlagKarpenter          = "Karpenter"
 
-	//	KubernetesSupportedMajorVersion is the latest major version of Kubernetes that Kaito supports.
-	KubernetesSupportedMajorVersion = "29"
+	//	RequiredKubernetesVersionForNodeClaim is the latest major version of Kubernetes that Kaito supports.
+	RequiredKubernetesVersionForNodeClaim = "29"
 )

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -8,4 +8,7 @@ const (
 	WorkspaceFinalizer            = "workspace.finalizer.kaito.sh"
 	DefaultReleaseNamespaceEnvVar = "RELEASE_NAMESPACE"
 	FeatureFlagKarpenter          = "Karpenter"
+
+	//	KubernetesSupportedMajorVersion is the latest major version of Kubernetes that Kaito supports.
+	KubernetesSupportedMajorVersion = "29"
 )

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -8,7 +8,4 @@ const (
 	WorkspaceFinalizer            = "workspace.finalizer.kaito.sh"
 	DefaultReleaseNamespaceEnvVar = "RELEASE_NAMESPACE"
 	FeatureFlagKarpenter          = "Karpenter"
-
-	//	RequiredKubernetesVersionForNodeClaim is the latest major version of Kubernetes that Kaito supports.
-	RequiredKubernetesVersionForNodeClaim = "29"
 )

--- a/pkg/utils/test/testUtils.go
+++ b/pkg/utils/test/testUtils.go
@@ -156,8 +156,8 @@ var (
 	}
 
 	nodeClaimLabels = map[string]string{
-		"karpenter.sh/nodepool-name": "default",
-		"kaito.sh/workspace":         "none",
+		"karpenter.sh/nodepool": "kaito",
+		"kaito.sh/workspace":    "none",
 	}
 )
 


### PR DESCRIPTION
**Reason for Change**:
- Workspace controller can support `nodeClaims` API.

Workspace controller won't migrate the current `machine` nodes. The behavior for CRUD operation:

**Create**
   - Both `nodeClaims` or `Machine` APIs will be used to create a node based on featureGate,

**Ownership**
   - Both `machines` and `nodeClaims` objects which created by the same workspace will be associated to it until got deleted. 

**Delete**
   - Deleting the workspace will delete both (if any) old `machines` objects and `nodeClaims`.

- Add unit tests for supporting node claims, and managing migrated clusters (both machines and nodeClaims).
- Replace the deprecated func `FromInt` with `FromInt32`.
- Update error message lint warning, start with lowercase characters.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
#339 

**Notes for Reviewers**: