### PR TITLE
feat: Add support for target_modules List

### DIFF
--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -116,7 +116,7 @@ func defaultConfigMapManifest() *v1.ConfigMap {
   LoraConfig:
     r: 16
     lora_alpha: 32
-    target_modules: "query_key_value"
+    target_modules: ["query_key_value"]
     lora_dropout: 0.05
     bias: "none"
 

--- a/presets/tuning/text-generation/parser.py
+++ b/presets/tuning/text-generation/parser.py
@@ -26,6 +26,10 @@ def flatten_config_to_cli_args(config, prefix=''):
     for key, value in config.items():
         if isinstance(value, dict):
             cli_args.extend(flatten_config_to_cli_args(value, prefix=f'{prefix}{key}_'))
+        elif isinstance(value, list):
+            cli_arg = f'--{prefix}{key}'
+            cli_args.append(cli_arg)
+            cli_args.extend(map(str, value))
         else:
             cli_arg = f'--{prefix}{key}'
             cli_args.append(cli_arg)


### PR DESCRIPTION
**Reason for Change**:
`target_modules` LoRAConfig parameter specifies which parts of the model should be adapted using LoRA. It can either be a string or string array. This PR adds support for array type arguments. It also does a validation check that target_modules is either of type string or string array. 

Example usage of target modules here

https://github.com/huggingface/peft/blob/main/src/peft/tuners/lora/config.py#L51-L58

https://stackoverflow.com/questions/76768226/target-modules-for-applying-peft-lora-on-different-models

