### PR TITLE
fix: Preset Build Image Naming

### DIFF
--- a/.github/actions/build-image-action/action.yml
+++ b/.github/actions/build-image-action/action.yml
@@ -134,6 +134,7 @@ runs:
         ACR_NAME=${{ inputs.acr_name }} \
         ACR_USERNAME=${{ inputs.acr_username }} \
         ACR_PASSWORD=${{ inputs.acr_password }} \
+        IMAGE_NAME=${{ inputs.image_name }} \
         MODEL_NAME=${{ inputs.model_name }} \
         MODEL_TYPE=${{ inputs.model_type }} \
         MODEL_VERSION=${{ inputs.model_version }} \

--- a/.github/workflows/kind-cluster/main.py
+++ b/.github/workflows/kind-cluster/main.py
@@ -99,6 +99,7 @@ def download_new_model(model_name, model_url):
 def main():
     pr_branch = os.environ.get("PR_BRANCH", "main")
     model_name = os.environ.get("MODEL_NAME", None)
+    image_name = os.environ.get("IMAGE_NAME", model_name)
     model_version = os.environ.get("MODEL_VERSION", None)
     model_runtime = os.environ.get("MODEL_RUNTIME", None)
     model_type = os.environ.get("MODEL_TYPE", None)
@@ -114,7 +115,7 @@ def main():
 
     unique_id = generate_unique_id()
     job_name = f"{model_name}-{unique_id}"
-    job_yaml = populate_job_template(model_name, model_type, model_runtime, model_tag, job_name, os.environ)
+    job_yaml = populate_job_template(image_name, model_name, model_type, model_runtime, model_tag, job_name, os.environ)
     write_job_file(job_yaml, job_name)
 
     weights = run_command(f"ls {WEIGHTS_FOLDER}")
@@ -153,7 +154,7 @@ def clone_and_checkout_pr_branch(pr_branch):
 
     os.chdir(Path.cwd().parent)
 
-def populate_job_template(model_name, model_type, model_runtime, model_tag, job_name, env_vars):
+def populate_job_template(image_name, model_name, model_type, model_runtime, model_tag, job_name, env_vars):
     """Populate the job template with provided values."""
     try:
         docker_job_template = Path.cwd() / "repo/.github/workflows/kind-cluster/docker-job-template.yaml"
@@ -162,7 +163,7 @@ def populate_job_template(model_name, model_type, model_runtime, model_tag, job_
 
         replacements = {
             "{{JOB_ID}}": f"{job_name}",
-            "{{IMAGE_NAME}}": f"{model_name}",
+            "{{IMAGE_NAME}}": f"{image_name}",
             "{{ACR_NAME}}": env_vars["ACR_NAME"],
             "{{ACR_USERNAME}}": env_vars["ACR_USERNAME"],
             "{{ACR_PASSWORD}}": env_vars["ACR_PASSWORD"],


### PR DESCRIPTION
**Reason for Change**:
Preset images use their model name as the name of the image by default. Instead we pass in seperate image name variable to name the image.