### PR TITLE
chore: remove deprecated goreleaser release actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           version: latest
-          args: release --rm-dist --timeout 60m --debug
+          args: release --clean --timeout 60m --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.client_payload.tag }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
           version: latest
-          args: release --clean --timeout 60m --debug
+          args: release --clean --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ github.event.client_payload.tag }}


### PR DESCRIPTION
**Reason for Change**:
The gorelaser release following subcommands has been changed:
- `--rm-dist` [deprecated](https://github.com/goreleaser/goreleaser/blob/main/www/docs/deprecations.md#--rm-dist) and replaced by `--clean`
- `--debug` [deprecated](https://github.com/goreleaser/goreleaser/blob/main/www/docs/deprecations.md#--debug) and replaced by `--verbose`

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: