### PR TITLE
fix: increase e2e test suite timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ GINKGO_FOCUS ?=
 GINKGO_SKIP ?=
 GINKGO_NODES ?= 1
 GINKGO_NO_COLOR ?= false
-GINKGO_TIMEOUT ?= 60m
+GINKGO_TIMEOUT ?= 180m
 GINKGO_ARGS ?= -focus="$(GINKGO_FOCUS)" -skip="$(GINKGO_SKIP)" -nodes=$(GINKGO_NODES) -no-color=$(GINKGO_NO_COLOR) -timeout=$(GINKGO_TIMEOUT)
 
 .PHONY: kaito-workspace-e2e-test


### PR DESCRIPTION
Since we start to add more and more e2e tests, the 60m suite timeout is too short. Increase the timeout to 3h. 
