### PR TITLE
feat: Add Dataset Image Use for E2E Tests

### DIFF
--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -134,6 +134,13 @@ jobs:
           make docker-build-adapter
         env:
           REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+      
+      - name: build dataset image
+        shell: bash
+        run: |
+          make docker-build-dataset
+        env:
+          REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
 
       - name: create cluster
         shell: bash
@@ -210,7 +217,7 @@ jobs:
           REGISTRY: ${{ env.REGISTRY }}
           AI_MODELS_REGISTRY: ${{ secrets.E2E_ACR_AMRT_USERNAME }}.azurecr.io
           AI_MODELS_REGISTRY_SECRET: ${{ secrets.E2E_AMRT_SECRET_NAME }}
-          ADAPTER_REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+          E2E_ACR_REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
 
       - name: Cleanup e2e resources
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,15 @@ docker-build-adapter: docker-buildx
 		--pull \
 		--tag $(REGISTRY)/e2e-adapter:0.0.1 .
 
+.PHONY: docker-build-dataset
+docker-build-dataset: docker-buildx
+	docker buildx build \
+		--file ./docker/dataset/Dockerfile \
+		--output=$(OUTPUT_TYPE) \
+		--platform="linux/$(ARCH)" \
+		--pull \
+		--tag $(REGISTRY)/e2e-dataset:0.0.1 .
+
 ##@ Deployment
 
 ifndef ignore-not-found

--- a/docker/dataset/Dockerfile
+++ b/docker/dataset/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox:latest
+
+RUN mkdir -p /data
+
+COPY docker/dataset/dataset.parquet /data/

--- a/docker/dataset/README.md
+++ b/docker/dataset/README.md
@@ -1,0 +1,21 @@
+# E2E Fine-Tuning Dataset Files
+
+## Overview
+
+This dataset file is used for conducting end-to-end (E2E) testing for fine-tuning. The Dockerfile builds an image incorporating the [dolly-15k-oai-style](https://huggingface.co/datasets/philschmid/dolly-15k-oai-style) dataset which is then used within an init container specifically for fine-tuning. 
+
+## Files
+
+- **Dockerfile**: Builds the Docker image for the E2E tests.
+
+- **dataset.parquet**: The dataset itself, downloaded from [dolly-15k-oai-style](https://huggingface.co/datasets/philschmid/dolly-15k-oai-style)
+
+
+## Usage
+
+Build the Docker image with the following command:
+
+```bash
+
+make docker-build-dataset
+ 

--- a/test/e2e/inference_with_adapters.go
+++ b/test/e2e/inference_with_adapters.go
@@ -19,7 +19,7 @@ import (
 var DefaultStrength = "1.0"
 
 var imageName = "e2e-adapter"
-var fullImageName = utils.GetEnv("ADAPTER_REGISTRY") + "/" + imageName + ":0.0.1"
+var fullImageName = utils.GetEnv("E2E_ACR_REGISTRY") + "/" + imageName + ":0.0.1"
 
 var validAdapters = []kaitov1alpha1.AdapterSpec{
 	{

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -306,7 +306,6 @@ func validateMachineCreation(workspaceObj *kaitov1alpha1.Workspace, expectedCoun
 					return condition.Type == apis.ConditionReady && condition.Status == v1.ConditionTrue
 				})
 				if !conditionFound {
-					fmt.Printf("Machine %s is not ready\n", machine.Name)
 					return false
 				}
 			}

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -271,7 +271,7 @@ func GenerateTuningWorkspaceManifest(name, namespace, imageName string, resource
 	return workspace
 }
 
-func GenerateE2ETuningWorkspaceManifest(name, namespace, imageName, outputRegistry string,
+func GenerateE2ETuningWorkspaceManifest(name, namespace, imageName, datasetImageName, outputRegistry string,
 	resourceCount int, instanceType string, labelSelector *metav1.LabelSelector,
 	preferredNodes []string, presetName kaitov1alpha1.ModelName, accessMode kaitov1alpha1.ModelImageAccessMode,
 	imagePullSecret []string, customConfigMapName string) *kaitov1alpha1.Workspace {
@@ -306,7 +306,7 @@ func GenerateE2ETuningWorkspaceManifest(name, namespace, imageName, outputRegist
 	workspace.Tuning = &workspaceTuning
 	workspace.Tuning.Method = kaitov1alpha1.TuningMethodQLora
 	workspace.Tuning.Input = &kaitov1alpha1.DataSource{
-		URLs: []string{ExampleDatasetURL},
+		Image: datasetImageName,
 	}
 	workspace.Tuning.Output = &kaitov1alpha1.DataDestination{
 		Image:           outputRegistry,


### PR DESCRIPTION
**Reason for Change**:
This PR ensures we use an image for dataset that is locally built during e2e as opposed to an external URL. 

This prevents flakey network errors that can waste entire pipeline runs.

Addresses - https://github.com/Azure/kaito/issues/531