### PR TITLE
fix: Keep Docker Sidecar Alive for Data Retrieval

### DIFF
--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -109,6 +109,26 @@ jobs:
           AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
           AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}
 
+      # Retrieve ACR credentials and create Kubernetes secret
+      - name: Set up ACR Credentials and Secret
+        shell: bash
+        run: |
+          # Retrieve the ACR username and password
+          ACR_USERNAME=$(az acr credential show --name ${{ env.CLUSTER_NAME }} --resource-group ${{ env.CLUSTER_NAME }} --query "username" -o tsv)
+          ACR_PASSWORD=$(az acr credential show --name ${{ env.CLUSTER_NAME }} --resource-group ${{ env.CLUSTER_NAME }} --query "passwords[0].value" -o tsv)
+
+          # Ensure credentials were retrieved successfully
+          if [ -z "$ACR_USERNAME" ] || [ -z "$ACR_PASSWORD" ]; then
+            echo "Failed to retrieve ACR credentials"
+            exit 1
+          fi
+
+          # Create the Kubernetes secret with the retrieved credentials
+          kubectl create secret docker-registry ${{ env.CLUSTER_NAME }}-acr-secret \
+          --docker-server=${{ env.CLUSTER_NAME }}.azurecr.io \
+          --docker-username=${ACR_USERNAME} \
+          --docker-password=${ACR_PASSWORD}
+
       - name: Create Azure Identity
         uses: azure/CLI@v2.0.0
         with:
@@ -218,6 +238,7 @@ jobs:
           AI_MODELS_REGISTRY: ${{ secrets.E2E_ACR_AMRT_USERNAME }}.azurecr.io
           AI_MODELS_REGISTRY_SECRET: ${{ secrets.E2E_AMRT_SECRET_NAME }}
           E2E_ACR_REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+          E2E_ACR_REGISTRY_SECRET: ${{ env.CLUSTER_NAME }}-acr-secret
 
       - name: Cleanup e2e resources
         if: ${{ always() }}

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -217,7 +217,8 @@ jobs:
           --docker-username=${ACR_USERNAME} \
           --docker-password=${ACR_PASSWORD}
 
-      - name: Add Private-Hosted Registry Secret Credentials
+      # Add Private-Hosted ACR secret for private models like llama
+      - name: Add Private-Hosted ACR Secret Credentials
         run: |
           kubectl create secret docker-registry ${{ secrets.E2E_AMRT_SECRET_NAME }} \
           --docker-server=${{ secrets.E2E_ACR_AMRT_USERNAME }}.azurecr.io \

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -109,26 +109,6 @@ jobs:
           AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
           AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}
 
-      # Retrieve ACR credentials and create Kubernetes secret
-      - name: Set up ACR Credentials and Secret
-        shell: bash
-        run: |
-          # Retrieve the ACR username and password
-          ACR_USERNAME=$(az acr credential show --name ${{ env.CLUSTER_NAME }} --resource-group ${{ env.CLUSTER_NAME }} --query "username" -o tsv)
-          ACR_PASSWORD=$(az acr credential show --name ${{ env.CLUSTER_NAME }} --resource-group ${{ env.CLUSTER_NAME }} --query "passwords[0].value" -o tsv)
-
-          # Ensure credentials were retrieved successfully
-          if [ -z "$ACR_USERNAME" ] || [ -z "$ACR_PASSWORD" ]; then
-            echo "Failed to retrieve ACR credentials"
-            exit 1
-          fi
-
-          # Create the Kubernetes secret with the retrieved credentials
-          kubectl create secret docker-registry ${{ env.CLUSTER_NAME }}-acr-secret \
-          --docker-server=${{ env.CLUSTER_NAME }}.azurecr.io \
-          --docker-username=${ACR_USERNAME} \
-          --docker-password=${ACR_PASSWORD}
-
       - name: Create Azure Identity
         uses: azure/CLI@v2.0.0
         with:
@@ -216,8 +196,28 @@ jobs:
           AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           REGISTRY: ${{ env.REGISTRY }}
           VERSION: ${{ env.VERSION }}
-            
-      - name: Add Secret Credentials
+
+      # Retrieve E2E ACR credentials and create Kubernetes secret
+      - name: Set up E2E ACR Credentials and Secret
+        shell: bash
+        run: |
+          # Retrieve the ACR username and password
+          ACR_USERNAME=$(az acr credential show --name ${{ env.CLUSTER_NAME }} --resource-group ${{ env.CLUSTER_NAME }} --query "username" -o tsv)
+          ACR_PASSWORD=$(az acr credential show --name ${{ env.CLUSTER_NAME }} --resource-group ${{ env.CLUSTER_NAME }} --query "passwords[0].value" -o tsv)
+
+          # Ensure credentials were retrieved successfully
+          if [ -z "$ACR_USERNAME" ] || [ -z "$ACR_PASSWORD" ]; then
+            echo "Failed to retrieve ACR credentials"
+            exit 1
+          fi
+
+          # Create the Kubernetes secret with the retrieved credentials
+          kubectl create secret docker-registry ${{ env.CLUSTER_NAME }}-acr-secret \
+          --docker-server=${{ env.CLUSTER_NAME }}.azurecr.io \
+          --docker-username=${ACR_USERNAME} \
+          --docker-password=${ACR_PASSWORD}
+
+      - name: Add Private-Hosted Registry Secret Credentials
         run: |
           kubectl create secret docker-registry ${{ secrets.E2E_AMRT_SECRET_NAME }} \
           --docker-server=${{ secrets.E2E_ACR_AMRT_USERNAME }}.azurecr.io \

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -271,7 +271,19 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 		re := regexp.MustCompile(`^(.+/[^:/]+):([^:/]+)$`)
 		if !re.MatchString(r.Image) {
 			errs = errs.Also(apis.ErrInvalidValue("Invalid image format, require full output image URL", "Image"))
+		} else {	// Executes if image is of correct format
+			// Extract repository name (part after the last / and before the colon :)
+			// Suppose r.Image == modelsregistry.azurecr.io/ADAPTER_HERE:0.0.1
+			parts := strings.Split(r.Image, "/")
+			lastPart := parts[len(parts)-1]           // Extracts "ADAPTER_HERE:0.0.1"
+			repoName := strings.Split(lastPart, ":")[0] // Extracts "ADAPTER_HERE"
+			
+			// Check if repository name is lowercase
+			if repoName != strings.ToLower(repoName) {
+				errs = errs.Also(apis.ErrInvalidValue("Repository name must be lowercase", "Image"))
+			}
 		}
+
 		// Cloud Provider requires credentials to push image
 		if r.ImagePushSecret == "" {
 			errs = errs.Also(apis.ErrMissingField("Must specify imagePushSecret with destination image"))

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -210,14 +210,14 @@ func (r *DataSource) validateCreate() (errs *apis.FieldError) {
 		re := regexp.MustCompile(`^(.+/[^:/]+):([^:/]+)$`)
 		if !re.MatchString(r.Image) {
 			errs = errs.Also(apis.ErrInvalidValue("Invalid image format, require full input image URL", "Image"))
+		} else {
+			// Executes if image is of correct format
+			err := utils.ExtractAndValidateRepoName(r.Image)
+			if err != nil {
+				errs = errs.Also(apis.ErrInvalidValue(err.Error(), "Image"))
+			}
 		}
 		sourcesSpecified++
-	} else {
-		// Executes if image is of correct format
-		err := utils.ExtractAndValidateRepoName(r.Image)
-		if err != nil {
-			errs = errs.Also(apis.ErrInvalidValue(err.Error(), "Image"))
-		}
 	}
 
 	// Ensure exactly one of URLs, Volume, or Image is specified

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -212,6 +212,12 @@ func (r *DataSource) validateCreate() (errs *apis.FieldError) {
 			errs = errs.Also(apis.ErrInvalidValue("Invalid image format, require full input image URL", "Image"))
 		}
 		sourcesSpecified++
+	} else {
+		// Executes if image is of correct format
+		err := utils.ExtractAndValidateRepoName(r.Image)
+		if err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(err.Error(), "Image"))
+		}
 	}
 
 	// Ensure exactly one of URLs, Volume, or Image is specified
@@ -271,16 +277,11 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 		re := regexp.MustCompile(`^(.+/[^:/]+):([^:/]+)$`)
 		if !re.MatchString(r.Image) {
 			errs = errs.Also(apis.ErrInvalidValue("Invalid image format, require full output image URL", "Image"))
-		} else {	// Executes if image is of correct format
-			// Extract repository name (part after the last / and before the colon :)
-			// Suppose r.Image == modelsregistry.azurecr.io/ADAPTER_HERE:0.0.1
-			parts := strings.Split(r.Image, "/")
-			lastPart := parts[len(parts)-1]           // Extracts "ADAPTER_HERE:0.0.1"
-			repoName := strings.Split(lastPart, ":")[0] // Extracts "ADAPTER_HERE"
-			
-			// Check if repository name is lowercase
-			if repoName != strings.ToLower(repoName) {
-				errs = errs.Also(apis.ErrInvalidValue("Repository name must be lowercase", "Image"))
+		} else {
+			// Executes if image is of correct format
+			err := utils.ExtractAndValidateRepoName(r.Image)
+			if err != nil {
+				errs = errs.Also(apis.ErrInvalidValue(err.Error(), "Image"))
 			}
 		}
 

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -284,7 +284,6 @@ func (r *DataDestination) validateCreate() (errs *apis.FieldError) {
 				errs = errs.Also(apis.ErrInvalidValue(err.Error(), "Image"))
 			}
 		}
-
 		// Cloud Provider requires credentials to push image
 		if r.ImagePushSecret == "" {
 			errs = errs.Also(apis.ErrMissingField("Must specify imagePushSecret with destination image"))

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -1069,6 +1069,17 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			errFields: []string{"Method"},
 		},
 		{
+			name: "Invalid Input Source Casing",
+			tuningSpec: &TuningSpec{
+				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/INPUT:0.0.0"},
+				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/output:0.0.0", ImagePushSecret: "secret"},
+				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
+				Method: TuningMethodLora,
+			},
+			wantErr:   true,
+			errFields: []string{"Image"},
+		},
+		{
 			name: "Invalid Output Destination Casing",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/input:0.0.0"},

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -1068,6 +1068,17 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			wantErr:   true,
 			errFields: []string{"Method"},
 		},
+		{
+			name: "Invalid Output Destination Casing",
+			tuningSpec: &TuningSpec{
+				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/input:0.0.0"},
+				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/OUTPUT:0.0.0", ImagePushSecret: "secret"},
+				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
+				Method: TuningMethodLora,
+			},
+			wantErr:   true,
+			errFields: []string{"Image"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
 	"reflect"
 	"sort"
 	"strings"
@@ -152,54 +151,25 @@ func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *ka
 			}
 			return reconcile.Result{}, err
 		}
-
-		// Get the Job associated with the Workspace
+		// Only mark workspace succeeded when job completes.
 		job := &batchv1.Job{}
-		if err = resources.GetResource(ctx, wObj.Name, wObj.Namespace, c.Client, job); err != nil {
-			klog.ErrorS(err, "failed to get job resource", "workspace", klog.KObj(wObj))
-			return reconcile.Result{}, err
-		}
-
-		// Get the Pod associated with this Job
-		podList := &corev1.PodList{}
-		if err = c.Client.List(ctx, podList, &client.ListOptions{
-			Namespace:     job.Namespace,
-			LabelSelector: labels.SelectorFromSet(job.Spec.Template.Labels),
-		}); err != nil {
-			klog.ErrorS(err, "failed to get pods for job", "job", klog.KObj(job))
-			return reconcile.Result{}, err
-		}
-
-		if len(podList.Items) == 0 {
-			klog.V(4).InfoS("No pods found for job, waiting", "job", klog.KObj(job))
-			return reconcile.Result{}, nil
-		}
-
-		pod := &podList.Items[0]
-		isMainContainerComplete := false
-
-		// Check if the main container has completed
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			if containerStatus.Name == wObj.Name { // Main container name matches the Workspace name
-				if containerStatus.State.Terminated != nil && containerStatus.State.Terminated.ExitCode == 0 {
-					isMainContainerComplete = true
-					break
+		if err = resources.GetResource(ctx, wObj.Name, wObj.Namespace, c.Client, job); err == nil {
+			if job.Status.Succeeded > 0 {
+				if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeSucceeded, metav1.ConditionTrue,
+					"workspaceSucceeded", "workspace succeeds"); updateErr != nil {
+					klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+					return reconcile.Result{}, updateErr
+				}
+			} else { // The job is still running
+				if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse,
+					"workspacePending", "workspace has not completed"); updateErr != nil {
+					klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+					return reconcile.Result{}, updateErr
 				}
 			}
-		}
-
-		if isMainContainerComplete {
-			if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeSucceeded, metav1.ConditionTrue,
-				"workspaceSucceeded", "workspace succeeds"); updateErr != nil {
-				klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
-				return reconcile.Result{}, updateErr
-			}
 		} else {
-			if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1alpha1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse,
-				"workspacePending", "workspace has not completed"); updateErr != nil {
-				klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
-				return reconcile.Result{}, updateErr
-			}
+			klog.ErrorS(err, "failed to get job resource", "workspace", klog.KObj(wObj))
+			return reconcile.Result{}, err
 		}
 	} else if wObj.Inference != nil {
 		if err := c.ensureService(ctx, wObj); err != nil {

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -175,10 +175,13 @@ while true; do
       ADD adapter_config.json /data/
       ADD adapter_model.safetensors /data/' > "$TEMP_CONTEXT/Dockerfile"
 
-      docker --config /root/.docker/config build -t %s "$TEMP_CONTEXT"
+	  # Add symbolic link to read-only mounted config.json
+	  ln -s /tmp/.docker/config/config.json /root/.docker/config.json
+
+      docker build -t %s "$TEMP_CONTEXT"
       
       while true; do
-        if docker --config /root/.docker/config push %s; then
+        if docker push %s; then
           echo "Upload complete"
           # Cleanup: Remove the temporary directory
           rm -rf "$TEMP_CONTEXT"

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -191,7 +191,7 @@ while true; do
           PUSH_SUCCEEDED=true
           # Signal completion
           touch /tmp/upload_complete
-          break
+          exit 0
         else
           echo "Push failed, retrying in 30 seconds..."
           sleep 30

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -173,15 +173,20 @@ while true; do
     ADD adapter_model.safetensors /data/' > "$TEMP_CONTEXT/Dockerfile"
 
     docker build -t %s "$TEMP_CONTEXT"
-    docker push %s
-
-    # Cleanup: Remove the temporary directory
-    rm -rf "$TEMP_CONTEXT"
-
-    # Remove the file to prevent repeated builds
-    rm "$FILE_PATH"
-    echo "Upload complete"
-    exit 0
+    
+    while true; do
+      if docker push %s; then
+        echo "Upload complete"
+        # Cleanup: Remove the temporary directory
+        rm -rf "$TEMP_CONTEXT"
+        # Remove the file to prevent repeated builds
+        rm "$FILE_PATH"
+        break
+      else
+        echo "Push failed, retrying in 30 seconds..."
+        sleep 30
+      fi
+    done
   fi
   sleep 10  # Check every 10 seconds
 done`, outputDir, image, image)

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -153,7 +153,6 @@ while ! docker info > /dev/null 2>&1; do
   sleep 1
 done
 echo 'Docker daemon started'
-touch /tmp/docker_ready
 
 PUSH_SUCCEEDED=false
 
@@ -385,17 +384,6 @@ func handleImageDataDestination(ctx context.Context, outputDir, image, imagePush
 		},
 		Command: []string{"/bin/sh", "-c"},
 		Args:    []string{dockerSidecarScriptPushImage(outputDir, image)},
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/bin/sh", "-c", "[ -f /tmp/docker_ready ]"},
-				},
-			},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       10,
-			FailureThreshold:    1, // Optional: Fail quickly if the probe fails
-			SuccessThreshold:    1, // Optional: Mark as ready immediately after the first success
-		},
 	}
 	volume, volumeMount := utils.ConfigImagePushSecretVolume(imagePushSecret)
 	return sidecarContainer, volume, volumeMount

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -175,10 +175,10 @@ while true; do
       ADD adapter_config.json /data/
       ADD adapter_model.safetensors /data/' > "$TEMP_CONTEXT/Dockerfile"
 
-      docker build -t %s "$TEMP_CONTEXT"
+      docker --config /root/.docker/config/config.json build -t %s "$TEMP_CONTEXT"
       
       while true; do
-        if docker push %s; then
+        if docker --config /root/.docker/config/config.json push %s; then
           echo "Upload complete"
           # Cleanup: Remove the temporary directory
           rm -rf "$TEMP_CONTEXT"

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -175,10 +175,10 @@ while true; do
       ADD adapter_config.json /data/
       ADD adapter_model.safetensors /data/' > "$TEMP_CONTEXT/Dockerfile"
 
-      docker --config /root/.docker/config/config.json build -t %s "$TEMP_CONTEXT"
+      docker --config /root/.docker/config build -t %s "$TEMP_CONTEXT"
       
       while true; do
-        if docker --config /root/.docker/config/config.json push %s; then
+        if docker --config /root/.docker/config push %s; then
           echo "Upload complete"
           # Cleanup: Remove the temporary directory
           rm -rf "$TEMP_CONTEXT"

--- a/pkg/tuning/preset-tuning.go
+++ b/pkg/tuning/preset-tuning.go
@@ -176,6 +176,7 @@ while true; do
       ADD adapter_model.safetensors /data/' > "$TEMP_CONTEXT/Dockerfile"
 
 	  # Add symbolic link to read-only mounted config.json
+      mkdir -p /root/.docker
 	  ln -s /tmp/.docker/config/config.json /root/.docker/config.json
 
       docker build -t %s "$TEMP_CONTEXT"

--- a/pkg/utils/common-preset.go
+++ b/pkg/utils/common-preset.go
@@ -31,12 +31,20 @@ func ConfigImagePushSecretVolume(imagePushSecret string) (corev1.Volume, corev1.
 	volume := corev1.Volume{
 		Name: "docker-config",
 		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: imagePushSecret,
-				Items: []corev1.KeyToPath{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{
 					{
-						Key:  ".dockerconfigjson",
-						Path: "config.json",
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: imagePushSecret,
+							},
+							Items: []corev1.KeyToPath{
+								{
+									Key:  ".dockerconfigjson",
+									Path: "config.json",
+								},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/utils/common-preset.go
+++ b/pkg/utils/common-preset.go
@@ -53,7 +53,7 @@ func ConfigImagePushSecretVolume(imagePushSecret string) (corev1.Volume, corev1.
 
 	volumeMount := corev1.VolumeMount{
 		Name:      "docker-config",
-		MountPath: "/root/.docker/config",
+		MountPath: "/tmp/.docker/config",
 	}
 
 	return volume, volumeMount

--- a/pkg/utils/common-preset.go
+++ b/pkg/utils/common-preset.go
@@ -53,8 +53,7 @@ func ConfigImagePushSecretVolume(imagePushSecret string) (corev1.Volume, corev1.
 
 	volumeMount := corev1.VolumeMount{
 		Name:      "docker-config",
-		MountPath: "/root/.docker/config.json",
-		SubPath:   "config.json", // Mount only the config.json file
+		MountPath: "/root/.docker/config",
 	}
 
 	return volume, volumeMount

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -16,6 +16,7 @@ import (
 	"knative.dev/pkg/apis"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 func Contains(s []string, e string) bool {
@@ -171,4 +172,19 @@ func GetPerNodeGPUCountFromNodes(nodeList *v1.NodeList) string {
 		}
 	}
 	return ""
+}
+
+func ExtractAndValidateRepoName(image string) error {
+	// Extract repository name (part after the last / and before the colon :)
+	// For example given image: modelsregistry.azurecr.io/ADAPTER_HERE:0.0.1
+	parts := strings.Split(image, "/")
+	lastPart := parts[len(parts)-1]             // Extracts "ADAPTER_HERE:0.0.1"
+	repoName := strings.Split(lastPart, ":")[0] // Extracts "ADAPTER_HERE"
+
+	// Check if repository name is lowercase
+	if repoName != strings.ToLower(repoName) {
+		return fmt.Errorf("Repository name must be lowercase")
+	}
+
+	return nil
 }

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -53,8 +53,11 @@ func loadTestEnvVars() {
 		runLlama13B = false
 	}
 
+	// Required for Llama models
 	aiModelsRegistry = utils.GetEnv("AI_MODELS_REGISTRY")
 	aiModelsRegistrySecret = utils.GetEnv("AI_MODELS_REGISTRY_SECRET")
+	// Currently required for uploading fine-tuning results
+	e2eACRSecret = utils.GetEnv("E2E_ACR_REGISTRY_SECRET")
 	supportedModelsYamlPath = utils.GetEnv("SUPPORTED_MODELS_YAML_PATH")
 	azureClusterName = utils.GetEnv("AZURE_CLUSTER_NAME")
 }
@@ -224,7 +227,7 @@ func createPhi3TuningWorkspaceWithPresetPublicMode(configMapName string, numOfNo
 		workspaceObj = utils.GenerateE2ETuningWorkspaceManifest(uniqueID, namespaceName, "",
 			fullDatasetImageName, outputRegistryUrl, numOfNode, "Standard_NC6s_v3", &metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-tuning-falcon"},
-			}, nil, PresetPhi3Mini128kModel, kaitov1alpha1.ModelImageAccessModePublic, []string{aiModelsRegistrySecret}, configMapName)
+			}, nil, PresetPhi3Mini128kModel, kaitov1alpha1.ModelImageAccessModePublic, []string{e2eACRSecret}, configMapName)
 
 		createAndValidateWorkspace(workspaceObj)
 	})
@@ -543,6 +546,7 @@ func deleteWorkspace(workspaceObj *kaitov1alpha1.Workspace) error {
 var runLlama13B bool
 var aiModelsRegistry string
 var aiModelsRegistrySecret string
+var e2eACRSecret string
 var supportedModelsYamlPath string
 var modelInfo map[string]string
 var azureClusterName string
@@ -708,7 +712,7 @@ var _ = Describe("Workspace Preset", func() {
 
 	It("should create a workspace for tuning successfully", func() {
 		numOfNode := 1
-		err := copySecretToNamespace(aiModelsRegistrySecret, namespaceName)
+		err := copySecretToNamespace(e2eACRSecret, namespaceName)
 		if err != nil {
 			log.Fatalf("Error copying secret: %v", err)
 		}

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -56,6 +56,7 @@ func loadTestEnvVars() {
 	aiModelsRegistry = utils.GetEnv("AI_MODELS_REGISTRY")
 	aiModelsRegistrySecret = utils.GetEnv("AI_MODELS_REGISTRY_SECRET")
 	supportedModelsYamlPath = utils.GetEnv("SUPPORTED_MODELS_YAML_PATH")
+	azureClusterName = utils.GetEnv("AZURE_CLUSTER_NAME")
 }
 
 func loadModelVersions() {


### PR DESCRIPTION
**Reason for Change**:
- Keep the docker sidecar container alive so incase ACR push fails we can still exec into the container to retrieve completed tuning job files in the /mnt/results folder.

- Perform validation check for output images that are uppercase

- Use projected volume for mounting docker config secrets - mount at directory location /root/.docker/config

- Add secret for E2E Temp ACR