### PR TITLE
ci: adding workflow dispatch to helm-chart workflow

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -3,6 +3,7 @@ name: publish_helm_chart
 on:
   repository_dispatch:
     types: [ create-release ]
+  workflow_dispatch:
 
 permissions:
   id-token: write # This is required for requesting the JWT


### PR DESCRIPTION
**Reason for Change**:
To be able to run helm chart publish workflows on demand. I noticed the latest version (0.3.0) of the helm chart is not published to https://azure.github.io/kaito/charts/kaito and looks like this can be resolved by simply re-running the publish workflow (without creating a new release). 

Confirmed this works in my fork of the kaito repo. Re-running the workflow published new chart version 0.3.0 (with app version 0.3.0)

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:

Verify helm chart and app versions

```
helm repo add kaito https://azure.github.io/kaito/charts/kaito
helm search repo --versions kaito/workspace
helm search repo --versions kaito/gpu-provisioner
```
