### PR TITLE
feat: Update controllerRevision and deployment lifecycle 

### DIFF
--- a/api/v1alpha1/workspace_labels.go
+++ b/api/v1alpha1/workspace_labels.go
@@ -18,4 +18,7 @@ const (
 
 	// LabelWorkspaceName is the label for workspace namespace.
 	LabelWorkspaceNamespace = KAITOPrefix + "workspacenamespace"
+
+	// WorkspaceRevisionAnnotation is the Annotations for revision number
+	WorkspaceRevisionAnnotation = "workspace.kaito.io/revision"
 )

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -9,8 +9,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,10 +52,10 @@ import (
 )
 
 const (
-	gpuSkuPrefix                = "Standard_N"
-	nodePluginInstallTimeout    = 60 * time.Second
-	WorkspaceRevisionAnnotation = "workspace.kaito.io/revision"
-	WorkspaceNameLabel          = "workspace.kaito.io/name"
+	gpuSkuPrefix             = "Standard_N"
+	nodePluginInstallTimeout = 60 * time.Second
+	WorkspaceHashAnnotation  = "workspace.kaito.io/hash"
+	WorkspaceNameLabel       = "workspace.kaito.io/name"
 )
 
 type WorkspaceReconciler struct {
@@ -85,6 +85,10 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	klog.InfoS("Reconciling", "workspace", req.NamespacedName)
 
+	if err := c.syncControllerRevision(ctx, workspaceObj); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if err := c.ensureFinalizer(ctx, workspaceObj); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -103,11 +107,6 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	result, err := c.addOrUpdateWorkspace(ctx, workspaceObj)
 	if err != nil {
 		return result, err
-	}
-
-	if err := c.updateControllerRevision(ctx, workspaceObj); err != nil {
-		klog.ErrorS(err, "failed to update ControllerRevision", "workspace", klog.KObj(workspaceObj))
-		return reconcile.Result{}, nil
 	}
 
 	return result, nil
@@ -213,20 +212,14 @@ func (c *WorkspaceReconciler) deleteWorkspace(ctx context.Context, wObj *kaitov1
 
 	return c.garbageCollectWorkspace(ctx, wObj)
 }
-
-func (c *WorkspaceReconciler) updateControllerRevision(ctx context.Context, wObj *kaitov1alpha1.Workspace) error { // TODO: Move non-updateControllerRevision related logic to separate functions
+func (c *WorkspaceReconciler) syncControllerRevision(ctx context.Context, wObj *kaitov1alpha1.Workspace) error {
 	currentHash := computeHash(wObj)
 	annotations := wObj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	} // nil checking.
 
-	latestHash, exists := annotations[WorkspaceRevisionAnnotation]
-	if exists && latestHash == currentHash {
-		return nil
-	}
-
-	jsonData, err := json.Marshal(wObj)
-	if err != nil {
-		return fmt.Errorf("failed to marshal revision data: %w", err)
-	}
+	revisionNum := int64(1)
 
 	revisions := &appsv1.ControllerRevisionList{}
 	if err := c.List(ctx, revisions, client.InNamespace(wObj.Namespace), client.MatchingLabels{WorkspaceNameLabel: wObj.Name}); err != nil {
@@ -236,35 +229,27 @@ func (c *WorkspaceReconciler) updateControllerRevision(ctx context.Context, wObj
 		return revisions.Items[i].Revision < revisions.Items[j].Revision
 	})
 
-	revisionNum := int64(1)
 	var latestRevision *appsv1.ControllerRevision
-	var previousWObj *kaitov1alpha1.Workspace
 
-	if len(revisions.Items) > 0 {
-		revisionNum = revisions.Items[len(revisions.Items)-1].Revision + 1
-		for i := range revisions.Items {
-			if revisions.Items[i].Annotations[WorkspaceRevisionAnnotation] == latestHash {
-				latestRevision = &revisions.Items[i]
-				break
-			}
-		}
-		if latestRevision != nil {
-			previousWObj = &kaitov1alpha1.Workspace{}
-			if err := json.Unmarshal(latestRevision.Data.Raw, previousWObj); err != nil {
-				return fmt.Errorf("failed to unmarshal previous workspace object: %w", err)
-			}
-		}
+	jsonData, err := marshalSelectedFields(wObj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal revision data: %w", err)
 	}
 
+	if len(revisions.Items) > 0 {
+		latestRevision = &revisions.Items[len(revisions.Items)-1]
+
+		revisionNum = latestRevision.Revision + 1
+	}
 	newRevision := &appsv1.ControllerRevision{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", wObj.Name, currentHash[:8]),
+			Name:      fmt.Sprintf("%s-%s", wObj.Name, currentHash[:5]),
 			Namespace: wObj.Namespace,
+			Annotations: map[string]string{
+				WorkspaceHashAnnotation: currentHash,
+			},
 			Labels: map[string]string{
 				WorkspaceNameLabel: wObj.Name,
-			},
-			Annotations: map[string]string{
-				WorkspaceRevisionAnnotation: currentHash,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(wObj, kaitov1alpha1.GroupVersion.WithKind("Workspace")),
@@ -274,75 +259,57 @@ func (c *WorkspaceReconciler) updateControllerRevision(ctx context.Context, wObj
 		Data:     runtime.RawExtension{Raw: jsonData},
 	}
 
-	if annotations == nil {
-		annotations = make(map[string]string)
-	} // nil checking.
-
-	annotations[WorkspaceRevisionAnnotation] = currentHash
+	annotations[WorkspaceHashAnnotation] = currentHash
 	wObj.SetAnnotations(annotations)
-	deployment := &appsv1.Deployment{}
-	if wObj.Inference != nil {
-		if previousWObj == nil || !compareAdapters(previousWObj.Inference.Adapters, wObj.Inference.Adapters) {
-			if err := c.Get(ctx, types.NamespacedName{
-				Name:      wObj.Name,
-				Namespace: wObj.Namespace,
-			}, deployment); err != nil {
-				if !errors.IsNotFound(err) {
-					klog.ErrorS(err, "failed to get deployment", "deplyment", wObj.Name)
-				}
-				return client.IgnoreNotFound(err)
-			}
-			if deployment.Annotations == nil {
-				deployment.Annotations = make(map[string]string)
+	controllerRevision := &appsv1.ControllerRevision{}
+	if err := c.Get(ctx, types.NamespacedName{
+		Name:      newRevision.Name,
+		Namespace: newRevision.Namespace,
+	}, controllerRevision); err != nil {
+		if errors.IsNotFound(err) {
+
+			if err := c.Create(ctx, newRevision); err != nil {
+				return fmt.Errorf("failed to create new ControllerRevision: %w", err)
+			} else {
+				annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] = strconv.FormatInt(revisionNum, 10)
 			}
 
-			if hash, exists := deployment.Annotations[WorkspaceRevisionAnnotation]; !exists || (hash != currentHash) {
-
-				var volumes []corev1.Volume
-				var volumeMounts []corev1.VolumeMount
-				shmVolume, shmVolumeMount := utils.ConfigSHMVolume(*wObj.Resource.Count)
-				if shmVolume.Name != "" {
-					volumes = append(volumes, shmVolume)
-				}
-				if shmVolumeMount.Name != "" {
-					volumeMounts = append(volumeMounts, shmVolumeMount)
-				}
-
-				if len(wObj.Inference.Adapters) > 0 {
-					adapterVolume, adapterVolumeMount := utils.ConfigAdapterVolume()
-					volumes = append(volumes, adapterVolume)
-					volumeMounts = append(volumeMounts, adapterVolumeMount)
-				}
-
-				initContainers, envs := resources.GenerateInitContainers(wObj, volumeMounts)
-				spec := &deployment.Spec
-				spec.Template.Spec.InitContainers = initContainers
-				spec.Template.Spec.Containers[0].Env = envs
-				spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
-				deployment.Annotations[WorkspaceRevisionAnnotation] = currentHash
-				spec.Template.Spec.Volumes = volumes
-
-				if err := c.Update(ctx, deployment); err != nil {
-					return fmt.Errorf("failed to update deployment: %w", err)
+			if len(revisions.Items) > consts.MaxRevisionHistoryLimit {
+				if err := c.Delete(ctx, &revisions.Items[0]); err != nil {
+					return fmt.Errorf("failed to delete old revision: %w", err)
 				}
 			}
-
+		} else {
+			return fmt.Errorf("failed to get controller revision: %w", err)
 		}
+	} else {
+		if controllerRevision.Annotations[WorkspaceHashAnnotation] != newRevision.Annotations[WorkspaceHashAnnotation] {
+			return fmt.Errorf("revision name conflicts, the hash values are different")
+		}
+		annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] = strconv.FormatInt(controllerRevision.Revision, 10)
 	}
+	annotations[WorkspaceHashAnnotation] = currentHash
+	wObj.SetAnnotations(annotations)
+
 	if err := c.Update(ctx, wObj); err != nil {
 		return fmt.Errorf("failed to update Workspace annotations: %w", err)
 	}
-
-	if err := c.Create(ctx, newRevision); err != nil {
-		return fmt.Errorf("failed to create new ControllerRevision: %w", err)
-	}
-
-	if len(revisions.Items) > consts.MaxRevisionHistoryLimit {
-		if err := c.Delete(ctx, &revisions.Items[0]); err != nil {
-			return fmt.Errorf("failed to delete old revision: %w", err)
-		}
-	}
 	return nil
+}
+
+func marshalSelectedFields(wObj *kaitov1alpha1.Workspace) ([]byte, error) {
+	partialMap := map[string]interface{}{
+		"resource":  wObj.Resource,
+		"inference": wObj.Inference,
+		"tuning":    wObj.Tuning,
+	}
+
+	jsonData, err := json.Marshal(partialMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal selected fields: %w", err)
+	}
+
+	return jsonData, nil
 }
 
 func computeHash(w *kaitov1alpha1.Workspace) string {
@@ -352,35 +319,6 @@ func computeHash(w *kaitov1alpha1.Workspace) string {
 	encoder.Encode(w.Inference)
 	encoder.Encode(w.Tuning)
 	return hex.EncodeToString(hasher.Sum(nil))
-}
-
-func compareAdapters(oldAdapters, newAdapters []kaitov1alpha1.AdapterSpec) bool {
-	// If both slices are nil or empty, they are equal
-	if len(oldAdapters) == 0 && len(newAdapters) == 0 {
-		return true
-	}
-
-	// If only one of the slices is nil or empty, they are not equal
-	if len(oldAdapters) != len(newAdapters) {
-		return false
-	}
-
-	oldAdaptersMap := make(map[string]kaitov1alpha1.AdapterSpec)
-	for _, adapter := range oldAdapters {
-		key := fmt.Sprintf("%s-%s", adapter.Source.Name, *adapter.Strength)
-		oldAdaptersMap[key] = adapter
-	}
-
-	for _, adapter := range newAdapters {
-		key := fmt.Sprintf("%s-%s", adapter.Source.Name, *adapter.Strength)
-		oldAdapter, found := oldAdaptersMap[key]
-		if !found || !reflect.DeepEqual(oldAdapter, adapter) {
-			return false
-		}
-		delete(oldAdaptersMap, key)
-	}
-
-	return len(oldAdaptersMap) == 0
 }
 
 func (c *WorkspaceReconciler) selectWorkspaceNodes(qualified []*corev1.Node, preferred []string, previous []string, count int) []*corev1.Node {
@@ -822,8 +760,6 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 
 			inferenceParam := model.GetInferenceParameters()
 
-			// TODO: we only do create if it does not exist for preset model. Need to document it.
-
 			var existingObj client.Object
 			if model.SupportDistributedInference() {
 				existingObj = &appsv1.StatefulSet{}
@@ -831,16 +767,48 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 				existingObj = &appsv1.Deployment{}
 
 			}
-
+			revisionStr := wObj.Annotations[kaitov1alpha1.WorkspaceRevisionAnnotation]
 			if err = resources.GetResource(ctx, wObj.Name, wObj.Namespace, c.Client, existingObj); err == nil {
 				klog.InfoS("An inference workload already exists for workspace", "workspace", klog.KObj(wObj))
+				if !model.SupportDistributedInference() {
+					deployment := existingObj.(*appsv1.Deployment)
+					if deployment.Annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] != revisionStr {
+						var volumes []corev1.Volume
+						var volumeMounts []corev1.VolumeMount
+						shmVolume, shmVolumeMount := utils.ConfigSHMVolume(*wObj.Resource.Count)
+						if shmVolume.Name != "" {
+							volumes = append(volumes, shmVolume)
+						}
+						if shmVolumeMount.Name != "" {
+							volumeMounts = append(volumeMounts, shmVolumeMount)
+						}
+
+						if len(wObj.Inference.Adapters) > 0 {
+							adapterVolume, adapterVolumeMount := utils.ConfigAdapterVolume()
+							volumes = append(volumes, adapterVolume)
+							volumeMounts = append(volumeMounts, adapterVolumeMount)
+						}
+						initContainers, envs := resources.GenerateInitContainers(wObj, volumeMounts)
+						spec := &deployment.Spec
+
+						spec.Template.Spec.InitContainers = initContainers
+						spec.Template.Spec.Containers[0].Env = envs
+						spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+						deployment.Annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] = revisionStr
+						spec.Template.Spec.Volumes = volumes
+
+						if err := c.Update(ctx, deployment); err != nil {
+							return
+						}
+					}
+				}
 				if err = resources.CheckResourceStatus(existingObj, c.Client, inferenceParam.ReadinessTimeout); err != nil {
 					return
 				}
 			} else if apierrors.IsNotFound(err) {
 				var workloadObj client.Object
 				// Need to create a new workload
-				workloadObj, err = inference.CreatePresetInference(ctx, wObj, inferenceParam, model.SupportDistributedInference(), c.Client)
+				workloadObj, err = inference.CreatePresetInference(ctx, wObj, revisionStr, inferenceParam, model.SupportDistributedInference(), c.Client)
 				if err != nil {
 					return
 				}

--- a/pkg/controllers/workspace_controller_test.go
+++ b/pkg/controllers/workspace_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"gotest.tools/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -651,6 +652,25 @@ func TestApplyInferenceWithPreset(t *testing.T) {
 			workspace:     *test.MockWorkspaceDistributedModel,
 			expectedError: nil,
 		},
+
+		"Update deployment with new configuration": {
+			callMocks: func(c *test.MockClient) {
+				// Mocking existing Deployment object
+				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).
+					Run(func(args mock.Arguments) {
+						dep := args.Get(2).(*appsv1.Deployment)
+						*dep = test.MockDeploymentUpdated
+					}).
+					Return(nil)
+
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
+
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
+			},
+			workspace:     *test.MockWorkspaceWithPreset,
+			expectedError: nil,
+		},
 	}
 
 	for k, tc := range testcases {
@@ -964,79 +984,95 @@ func TestApplyWorkspaceResource(t *testing.T) {
 	}
 }
 
-func TestUpdateControllerRevision(t *testing.T) {
+func TestUpdateControllerRevision1(t *testing.T) {
 	testcases := map[string]struct {
 		callMocks     func(c *test.MockClient)
 		workspace     v1alpha1.Workspace
 		expectedError error
 		verifyCalls   func(c *test.MockClient)
 	}{
+
 		"No new revision needed": {
 			callMocks: func(c *test.MockClient) {
-				c.On("List", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything).Return(errors.New("should not be called"))
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything, mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).
+					Run(func(args mock.Arguments) {
+						dep := args.Get(2).(*appsv1.ControllerRevision)
+						*dep = appsv1.ControllerRevision{
+							ObjectMeta: v1.ObjectMeta{
+								Annotations: map[string]string{
+									WorkspaceHashAnnotation: "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+								},
+							},
+						}
+					}).
+					Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&kaitov1alpha1.Workspace{}), mock.Anything).
+					Return(nil)
 			},
 			workspace:     test.MockWorkspaceWithComputeHash,
 			expectedError: nil,
 			verifyCalls: func(c *test.MockClient) {
-				c.AssertNumberOfCalls(t, "List", 0)
+				c.AssertNumberOfCalls(t, "List", 1)
 				c.AssertNumberOfCalls(t, "Create", 0)
-				c.AssertNumberOfCalls(t, "Update", 0)
+				c.AssertNumberOfCalls(t, "Get", 1)
 				c.AssertNumberOfCalls(t, "Delete", 0)
+				c.AssertNumberOfCalls(t, "Update", 1)
 			},
 		},
+
 		"Fail to create ControllerRevision": {
 			callMocks: func(c *test.MockClient) {
-				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything, mock.Anything).Return(nil)
 				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).Return(errors.New("failed to create ControllerRevision"))
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).
-					Run(func(args mock.Arguments) {
-						dep := args.Get(2).(*appsv1.Deployment)
-						*dep = test.MockDeploymentWithAnnotationsAndContainer1
-					}).
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).
+					Return(apierrors.NewNotFound(appsv1.Resource("ControllerRevision"), test.MockWorkspaceFailToCreateCR.Name))
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&kaitov1alpha1.Workspace{}), mock.Anything).
 					Return(nil)
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
 			},
 			workspace:     test.MockWorkspaceFailToCreateCR,
 			expectedError: errors.New("failed to create new ControllerRevision: failed to create ControllerRevision"),
 			verifyCalls: func(c *test.MockClient) {
 				c.AssertNumberOfCalls(t, "List", 1)
 				c.AssertNumberOfCalls(t, "Create", 1)
-				c.AssertNumberOfCalls(t, "Update", 2)
+				c.AssertNumberOfCalls(t, "Get", 1)
 				c.AssertNumberOfCalls(t, "Delete", 0)
+				c.AssertNumberOfCalls(t, "Update", 0)
 			},
 		},
+
 		"Successfully create new ControllerRevision": {
 			callMocks: func(c *test.MockClient) {
-				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything, mock.Anything).Return(nil)
 				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).Return(nil)
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).
-					Run(func(args mock.Arguments) {
-						dep := args.Get(2).(*appsv1.Deployment)
-						*dep = test.MockDeploymentWithAnnotationsAndContainer2
-					}).
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).
+					Return(apierrors.NewNotFound(appsv1.Resource("ControllerRevision"), test.MockWorkspaceFailToCreateCR.Name))
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&kaitov1alpha1.Workspace{}), mock.Anything).
 					Return(nil)
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
 			},
 			workspace:     test.MockWorkspaceSuccessful,
 			expectedError: nil,
 			verifyCalls: func(c *test.MockClient) {
 				c.AssertNumberOfCalls(t, "List", 1)
 				c.AssertNumberOfCalls(t, "Create", 1)
-				c.AssertNumberOfCalls(t, "Update", 2)
+				c.AssertNumberOfCalls(t, "Get", 1)
 				c.AssertNumberOfCalls(t, "Delete", 0)
+				c.AssertNumberOfCalls(t, "Update", 1)
 			},
 		},
+
 		"Successfully delete old ControllerRevision": {
 			callMocks: func(c *test.MockClient) {
 				revisions := &appsv1.ControllerRevisionList{}
+				jsonData, _ := json.Marshal(test.MockWorkspaceWithUpdatedDeployment)
+
 				for i := 0; i <= consts.MaxRevisionHistoryLimit; i++ {
 					revision := &appsv1.ControllerRevision{
 						ObjectMeta: v1.ObjectMeta{
 							Name: fmt.Sprintf("revision-%d", i),
 						},
 						Revision: int64(i),
+						Data:     runtime.RawExtension{Raw: jsonData},
 					}
 					revisions.Items = append(revisions.Items, *revision)
 				}
@@ -1047,42 +1083,40 @@ func TestUpdateControllerRevision(t *testing.T) {
 					objKey := client.ObjectKeyFromObject(&m)
 					relevantMap[objKey] = &m
 				}
-
-				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything, mock.Anything).Return(nil)
 				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).Return(nil)
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).
-					Run(func(args mock.Arguments) {
-						dep := args.Get(2).(*appsv1.Deployment)
-						*dep = test.MockDeploymentWithAnnotationsAndContainer2
-					}).
-					Return(nil)
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).
+					Return(apierrors.NewNotFound(appsv1.Resource("ControllerRevision"), test.MockWorkspaceFailToCreateCR.Name))
 				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&kaitov1alpha1.Workspace{}), mock.Anything).
+					Return(nil)
 			},
 			workspace:     test.MockWorkspaceWithDeleteOldCR,
 			expectedError: nil,
 			verifyCalls: func(c *test.MockClient) {
 				c.AssertNumberOfCalls(t, "List", 1)
 				c.AssertNumberOfCalls(t, "Create", 1)
-				c.AssertNumberOfCalls(t, "Update", 2)
+				c.AssertNumberOfCalls(t, "Get", 1)
 				c.AssertNumberOfCalls(t, "Delete", 1)
+				c.AssertNumberOfCalls(t, "Update", 1)
 			},
 		},
-		"Deployment updated when adapters change": {
+
+		"Fail to update Workspace annotations": {
 			callMocks: func(c *test.MockClient) {
 				revisions := &appsv1.ControllerRevisionList{}
-				jsonData, _ := json.Marshal(test.MockWorkspaceWithComputeHash)
-				revision := &appsv1.ControllerRevision{
-					ObjectMeta: v1.ObjectMeta{
-						Name:        "revision-1",
-						Annotations: test.MockWorkspaceWithComputeHash.Annotations,
-					},
-					Revision: int64(1),
-					Data:     runtime.RawExtension{Raw: jsonData},
-				}
-				revisions.Items = append(revisions.Items, *revision)
+				jsonData, _ := json.Marshal(test.MockWorkspaceWithUpdatedDeployment)
 
+				for i := 0; i <= consts.MaxRevisionHistoryLimit; i++ {
+					revision := &appsv1.ControllerRevision{
+						ObjectMeta: v1.ObjectMeta{
+							Name: fmt.Sprintf("revision-%d", i),
+						},
+						Revision: int64(i),
+						Data:     runtime.RawExtension{Raw: jsonData},
+					}
+					revisions.Items = append(revisions.Items, *revision)
+				}
 				relevantMap := c.CreateMapWithType(revisions)
 
 				for _, obj := range revisions.Items {
@@ -1090,25 +1124,22 @@ func TestUpdateControllerRevision(t *testing.T) {
 					objKey := client.ObjectKeyFromObject(&m)
 					relevantMap[objKey] = &m
 				}
-
-				c.CreateOrUpdateObjectInMap(&test.MockDeploymentUpdated)
-
-				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything).Return(nil)
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevisionList{}), mock.Anything, mock.Anything).Return(nil)
 				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).Return(nil)
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&v1alpha1.Workspace{}), mock.Anything).Return(nil)
-
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
-
-				c.On("Update", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).
+					Return(apierrors.NewNotFound(appsv1.Resource("ControllerRevision"), test.MockWorkspaceFailToCreateCR.Name))
+				c.On("Delete", mock.IsType(context.Background()), mock.IsType(&appsv1.ControllerRevision{}), mock.Anything).Return(nil)
+				c.On("Update", mock.IsType(context.Background()), mock.IsType(&kaitov1alpha1.Workspace{}), mock.Anything).
+					Return(fmt.Errorf("failed to update Workspace annotations"))
 			},
-			workspace:     test.MockWorkspaceWithUpdatedDeployment,
-			expectedError: nil,
+			workspace:     test.MockWorkspaceUpdateCR,
+			expectedError: fmt.Errorf("failed to update Workspace annotations: %w", fmt.Errorf("failed to update Workspace annotations")),
 			verifyCalls: func(c *test.MockClient) {
 				c.AssertNumberOfCalls(t, "List", 1)
 				c.AssertNumberOfCalls(t, "Create", 1)
-				c.AssertNumberOfCalls(t, "Update", 2) // one for workspace and one for deployment
 				c.AssertNumberOfCalls(t, "Get", 1)
-				c.AssertNumberOfCalls(t, "Delete", 0)
+				c.AssertNumberOfCalls(t, "Delete", 1)
+				c.AssertNumberOfCalls(t, "Update", 1)
 			},
 		},
 	}
@@ -1123,7 +1154,7 @@ func TestUpdateControllerRevision(t *testing.T) {
 			}
 			ctx := context.Background()
 
-			err := reconciler.updateControllerRevision(ctx, &tc.workspace)
+			err := reconciler.syncControllerRevision(ctx, &tc.workspace)
 			if tc.expectedError == nil {
 				assert.Check(t, err == nil, "Not expected to return error")
 			} else {
@@ -1132,47 +1163,6 @@ func TestUpdateControllerRevision(t *testing.T) {
 			if tc.verifyCalls != nil {
 				tc.verifyCalls(mockClient)
 			}
-		})
-	}
-}
-
-func TestCompareAdapters(t *testing.T) {
-	testcases := map[string]struct {
-		oldAdapters    []kaitov1alpha1.AdapterSpec
-		newAdapters    []kaitov1alpha1.AdapterSpec
-		expectedResult bool
-	}{
-		"Both slices are empty": {
-			oldAdapters:    []kaitov1alpha1.AdapterSpec{},
-			newAdapters:    []kaitov1alpha1.AdapterSpec{},
-			expectedResult: true,
-		},
-		"One slice is empty": {
-			oldAdapters:    []kaitov1alpha1.AdapterSpec{},
-			newAdapters:    test.Adapters1,
-			expectedResult: false,
-		},
-		"Different lengths": {
-			oldAdapters:    test.Adapters1,
-			newAdapters:    test.Adapters2,
-			expectedResult: false,
-		},
-		"Different contents": {
-			oldAdapters:    test.Adapters2,
-			newAdapters:    test.Adapters4,
-			expectedResult: false,
-		},
-		"Same length and contents": {
-			oldAdapters:    test.Adapters2,
-			newAdapters:    test.Adapters3,
-			expectedResult: true,
-		},
-	}
-
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			result := compareAdapters(tc.oldAdapters, tc.newAdapters)
-			assert.Equal(t, tc.expectedResult, result, "Expected result did not match actual result")
 		})
 	}
 }

--- a/pkg/inference/preset-inferences.go
+++ b/pkg/inference/preset-inferences.go
@@ -113,7 +113,7 @@ func GetInferenceImageInfo(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 	}
 }
 
-func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
+func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace, revisionNum string,
 	inferenceObj *model.PresetParam, supportDistributedInference bool, kubeClient client.Client) (client.Object, error) {
 	if inferenceObj.TorchRunParams != nil && supportDistributedInference {
 		if err := updateTorchParamsForDistributedInference(ctx, kubeClient, workspaceObj, inferenceObj); err != nil {
@@ -152,7 +152,7 @@ func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 		depObj = resources.GenerateStatefulSetManifest(ctx, workspaceObj, image, imagePullSecrets, *workspaceObj.Resource.Count, commands,
 			containerPorts, livenessProbe, readinessProbe, resourceReq, tolerations, volumes, volumeMounts)
 	} else {
-		depObj = resources.GenerateDeploymentManifest(ctx, workspaceObj, image, imagePullSecrets, *workspaceObj.Resource.Count, commands,
+		depObj = resources.GenerateDeploymentManifest(ctx, workspaceObj, revisionNum, image, imagePullSecrets, *workspaceObj.Resource.Count, commands,
 			containerPorts, livenessProbe, readinessProbe, resourceReq, tolerations, volumes, volumeMounts)
 	}
 	err = resources.CreateResource(ctx, depObj, kubeClient)

--- a/pkg/inference/preset-inferences_test.go
+++ b/pkg/inference/preset-inferences_test.go
@@ -5,11 +5,12 @@ package inference
 
 import (
 	"context"
-	"github.com/azure/kaito/pkg/utils/consts"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/azure/kaito/pkg/utils/consts"
 
 	"github.com/azure/kaito/api/v1alpha1"
 	"github.com/azure/kaito/pkg/utils/test"
@@ -115,7 +116,7 @@ func TestCreatePresetInference(t *testing.T) {
 			}
 			mockClient.CreateOrUpdateObjectInMap(svc)
 
-			createdObject, _ := CreatePresetInference(context.TODO(), workspace, inferenceObj, useHeadlessSvc, mockClient)
+			createdObject, _ := CreatePresetInference(context.TODO(), workspace, test.MockWorkspaceWithPresetHash, inferenceObj, useHeadlessSvc, mockClient)
 			createdWorkload := ""
 			switch createdObject.(type) {
 			case *appsv1.Deployment:

--- a/pkg/resources/manifests.go
+++ b/pkg/resources/manifests.go
@@ -254,7 +254,7 @@ func GenerateTuningJobManifest(ctx context.Context, wObj *kaitov1alpha1.Workspac
 	}
 }
 
-func GenerateDeploymentManifest(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace, imageName string,
+func GenerateDeploymentManifest(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace, revisionNum string, imageName string,
 	imagePullSecretRefs []corev1.LocalObjectReference, replicas int, commands []string, containerPorts []corev1.ContainerPort,
 	livenessProbe, readinessProbe *corev1.Probe, resourceRequirements corev1.ResourceRequirements,
 	tolerations []corev1.Toleration, volumes []corev1.Volume, volumeMount []corev1.VolumeMount) *appsv1.Deployment {
@@ -293,9 +293,25 @@ func GenerateDeploymentManifest(ctx context.Context, workspaceObj *kaitov1alpha1
 					Controller: &controller,
 				},
 			},
+			Annotations: map[string]string{
+				kaitov1alpha1.WorkspaceRevisionAnnotation: revisionNum,
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: lo.ToPtr(int32(replicas)),
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxSurge: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 0,
+					},
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1,
+					},
+				}, // Configuration for rolling updates: allows no extra pods during the update and permits at most one unavailable pod at a time。
+			},
 			Selector: labelselector,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{

--- a/pkg/resources/manifests_test.go
+++ b/pkg/resources/manifests_test.go
@@ -6,8 +6,9 @@ package resources
 import (
 	"context"
 	"fmt"
-	"github.com/azure/kaito/pkg/utils/test"
 	"reflect"
+
+	"github.com/azure/kaito/pkg/utils/test"
 
 	"testing"
 
@@ -65,7 +66,7 @@ func TestGenerateDeploymentManifest(t *testing.T) {
 
 		workspace := test.MockWorkspaceWithPreset
 
-		obj := GenerateDeploymentManifest(context.TODO(), workspace,
+		obj := GenerateDeploymentManifest(context.TODO(), workspace, test.MockWorkspaceWithPresetHash,
 			"",  //imageName
 			nil, //imagePullSecretRefs
 			*workspace.Resource.Count,

--- a/pkg/utils/test/testUtils.go
+++ b/pkg/utils/test/testUtils.go
@@ -74,13 +74,16 @@ var (
 	}
 )
 
+var MockWorkspaceWithPresetHash = "89ae127050ec264a5ce84db48ef7226574cdf1299e6bd27fe90b927e34cc8adb"
+
 var (
 	MockWorkspaceWithDeleteOldCR = v1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testWorkspace",
 			Namespace: "kaito",
 			Annotations: map[string]string{
-				"workspace.kaito.io/revision": "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/hash":     "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/revision": "1",
 			},
 		},
 		Resource: v1alpha1.ResourceSpec{
@@ -105,9 +108,11 @@ var (
 var (
 	MockWorkspaceFailToCreateCR = v1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "testWorkspace-failedtocreateCR",
-			Namespace:   "kaito",
-			Annotations: map[string]string{},
+			Name:      "testWorkspace-failedtocreateCR",
+			Namespace: "kaito",
+			Annotations: map[string]string{
+				"workspace.kaito.io/revision": "1",
+			},
 		},
 		Resource: v1alpha1.ResourceSpec{
 			Count:        &gpuNodeCount,
@@ -131,9 +136,11 @@ var (
 var (
 	MockWorkspaceSuccessful = v1alpha1.Workspace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "testWorkspace-successful",
-			Namespace:   "kaito",
-			Annotations: map[string]string{},
+			Name:      "testWorkspace-successful",
+			Namespace: "kaito",
+			Annotations: map[string]string{
+				"workspace.kaito.io/revision": "0",
+			},
 		},
 		Resource: v1alpha1.ResourceSpec{
 			Count:        &gpuNodeCount,
@@ -160,7 +167,37 @@ var (
 			Name:      "testWorkspace",
 			Namespace: "kaito",
 			Annotations: map[string]string{
-				"workspace.kaito.io/revision": "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/hash":     "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/revision": "1",
+			},
+		},
+		Resource: v1alpha1.ResourceSpec{
+			Count:        &gpuNodeCount,
+			InstanceType: "Standard_NC12s_v3",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"workspace.kaito.io/name": "testWorkspace",
+				},
+			},
+		},
+		Inference: &v1alpha1.InferenceSpec{
+			Preset: &v1alpha1.PresetSpec{
+				PresetMeta: v1alpha1.PresetMeta{
+					Name: "test-model",
+				},
+			},
+		},
+	}
+)
+
+var (
+	MockWorkspaceUpdateCR = v1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testWorkspace",
+			Namespace: "kaito",
+			Annotations: map[string]string{
+				"workspace.kaito.io/hash":     "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/revision": "1",
 			},
 		},
 		Resource: v1alpha1.ResourceSpec{
@@ -188,7 +225,8 @@ var (
 			Name:      "testWorkspace",
 			Namespace: "kaito",
 			Annotations: map[string]string{
-				"workspace.kaito.io/revision": "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/hash":     "1171dc5d15043c92e684c8f06689eb241763a735181fdd2b59c8bd8fd6eecdd4",
+				"workspace.kaito.io/revision": "1",
 			},
 		},
 		Resource: v1alpha1.ResourceSpec{
@@ -220,13 +258,15 @@ var (
 )
 
 var (
+	numRep                = int32(1)
 	MockDeploymentUpdated = appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "testWorkspace",
 			Namespace:   "kaito",
-			Annotations: map[string]string{},
+			Annotations: map[string]string{v1alpha1.WorkspaceRevisionAnnotation: "1"},
 		},
 		Spec: appsv1.DeploymentSpec{
+			Replicas: &numRep,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -244,10 +284,33 @@ var (
 									Protocol:      corev1.ProtocolTCP,
 								},
 							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENV_VAR_NAME",
+									Value: "ENV_VAR_VALUE",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "volume-name",
+									MountPath: "/mount/path",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume-name",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
 						},
 					},
 				},
 			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 1,
 		},
 	}
 	MockDeploymentWithAnnotationsAndContainer1 = appsv1.Deployment{


### PR DESCRIPTION
**Reason for Change**:
1. Change "workspace.kaito.io/revision" to revision number, and make the hash result as "workspace.kaito.io/hash"
2. Sync contropllerrevision and workspace at the beginning of the Reconcile
3. Update the tests for the changes

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: