### PR TITLE
fix: Populate ImagePullSecrets in Adapter Deployment and Add Corresponding Tests

### DIFF
--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -818,6 +818,13 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 						spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 						deployment.Annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] = revisionStr
 						spec.Template.Spec.Volumes = volumes
+						if len(wObj.Inference.Adapters) > 0 {
+							for _, adapter := range wObj.Inference.Adapters {
+								for _, secretName := range adapter.Source.ImagePullSecrets {
+									spec.Template.Spec.ImagePullSecrets = append(spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+								}
+							}
+						}
 
 						if err := c.Update(ctx, deployment); err != nil {
 							return

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -818,13 +818,6 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 						spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 						deployment.Annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] = revisionStr
 						spec.Template.Spec.Volumes = volumes
-						if len(wObj.Inference.Adapters) > 0 {
-							for _, adapter := range wObj.Inference.Adapters {
-								for _, secretName := range adapter.Source.ImagePullSecrets {
-									spec.Template.Spec.ImagePullSecrets = append(spec.Template.Spec.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
-								}
-							}
-						}
 
 						if err := c.Update(ctx, deployment); err != nil {
 							return

--- a/pkg/inference/preset-inferences.go
+++ b/pkg/inference/preset-inferences.go
@@ -112,7 +112,6 @@ func GetInferenceImageInfo(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 		if len(workspaceObj.Inference.Adapters) > 0 {
 			for _, adapter := range workspaceObj.Inference.Adapters {
 				for _, secretName := range adapter.Source.ImagePullSecrets {
-					klog.InfoS("Adding image pull secret to deployment", "secretName", secretName)
 					imagePullSecretRefs = append(imagePullSecretRefs, corev1.LocalObjectReference{Name: secretName})
 				}
 			}

--- a/pkg/inference/preset-inferences.go
+++ b/pkg/inference/preset-inferences.go
@@ -109,6 +109,14 @@ func GetInferenceImageInfo(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 		imageTag := presetObj.Tag
 		registryName := os.Getenv("PRESET_REGISTRY_NAME")
 		imageName = fmt.Sprintf("%s/kaito-%s:%s", registryName, imageName, imageTag)
+		if len(workspaceObj.Inference.Adapters) > 0 {
+			for _, adapter := range workspaceObj.Inference.Adapters {
+				for _, secretName := range adapter.Source.ImagePullSecrets {
+					klog.InfoS("Adding image pull secret to deployment", "secretName", secretName)
+					imagePullSecretRefs = append(imagePullSecretRefs, corev1.LocalObjectReference{Name: secretName})
+				}
+			}
+		}
 		return imageName, imagePullSecretRefs
 	}
 }

--- a/test/e2e/inference_with_adapters_test.go
+++ b/test/e2e/inference_with_adapters_test.go
@@ -41,7 +41,7 @@ var validAdapters2 = []kaitov1alpha1.AdapterSpec{
 			Name:  imageName2,
 			Image: fullImageName2,
 			ImagePullSecrets: []string{
-				utils.GetEnv("AI_MODELS_REGISTRY_SECRET"),
+				aiModelsRegistrySecret,
 			},
 		},
 		Strength: &DefaultStrength,

--- a/test/e2e/inference_with_adapters_test.go
+++ b/test/e2e/inference_with_adapters_test.go
@@ -40,6 +40,9 @@ var validAdapters2 = []kaitov1alpha1.AdapterSpec{
 		Source: &kaitov1alpha1.DataSource{
 			Name:  imageName2,
 			Image: fullImageName2,
+			ImagePullSecrets: []string{
+				utils.GetEnv("AI_MODELS_REGISTRY_SECRET"),
+			},
 		},
 		Strength: &DefaultStrength,
 	},
@@ -82,6 +85,9 @@ func validateInitContainers(workspaceObj *kaitov1alpha1.Workspace, expectedInitC
 				return false
 			}
 
+			if dep.Spec.Template.Spec.ImagePullSecrets == nil || len(dep.Spec.Template.Spec.ImagePullSecrets) == 0 {
+				return false
+			}
 			if len(initContainers) != len(expectedInitContainers) {
 				return false
 			}


### PR DESCRIPTION
**Reason for Change**:
fix the bug that adapter with ImagePullSecrets will not be populated to its deployment

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: